### PR TITLE
Fix buffer overflow in GenBye() RTCP BYE reason handling

### DIFF
--- a/src/conference.c
+++ b/src/conference.c
@@ -132,8 +132,8 @@
    2. Added the ability for Asterisk nodes to initiate connections to Echolink
       nodes by entering the 6 digit EchoLink node number.  Leading zeros must be
       entered for 4 and 5 digit nodes.
-   3. Added the ability for Asterisk nodes to disconnect the last EchoLink node by
-      connected by entering "000000".
+   3. Added the ability for Asterisk nodes to disconnect the last EchoLink node
+   by connected by entering "000000".
    4. Added -b, -c and -t arguments to the .users command.  The -b switch
       suppresses the display of the user's attributes.  The -c switch displays
       the amount of time each user has been connected.  The -t switch displays
@@ -148,7 +148,8 @@
    4. Added event hook support for Asterisk connections.
 
    Revision 1.52  2008/07/16 22:38:25  wb6ymh
-   1. Added (untested) support for full duplex clients (currently just thelinkbox).
+   1. Added (untested) support for full duplex clients (currently just
+   thelinkbox).
    2. Added code to enable the stock EchoLink client's DTMF pad when the
       configuration file variable EnableRemoteDTMF is set to 1.
    3. Modified logic to set bSendSSRC whenever an rtp packet is received with a
@@ -188,11 +189,11 @@
    Added CmdTxOffset, CmdRxFrequency, CmdRxTone, CmdTxTone.
 
    Revision 1.44  2008/04/11 18:33:49  wb6ymh
-   1. Added code to send an chat event to the event hook when a text chat message
-      is received from a user.
+   1. Added code to send an chat event to the event hook when a text chat
+   message is received from a user.
 
-   2. Added code to send an sent_chat event to the event hook when a chat message
-      is sent.
+   2. Added code to send an sent_chat event to the event hook when a chat
+   message is sent.
 
    3. Deleted the obsolete .dtmfgen command.
 
@@ -236,7 +237,8 @@
       but multiple packets are generated.
    4. Added code to display a usage message when the .monitor command is run
       without arguments.
-   5. Modified the users command to display an 'a' user attribute for ADPCM users.
+   5. Modified the users command to display an 'a' user attribute for ADPCM
+   users.
 
    Revision 1.38  2008/02/28 23:08:35  wb6ymh
    1. Corrected bug in Play4 (without -u option) command introduced in version
@@ -261,17 +263,19 @@
    4.  Corrected bugs created in CreateServerClient when SFBind2IP was added.
    5.  Modified code to initialize command line client using SF conference when
        EchoLink is disabled.
-   6.  Modified RTP_Data to only forward audio packet to clients running the same
-       codec as client speaking.
+   6.  Modified RTP_Data to only forward audio packet to clients running the
+   same codec as client speaking.
    7.  Removed newline from playbackcomplete event.
    8.  Clear bPlayWhenFree flag in PlayBackComplete.  Fixes crash which occured
        when a client disconnected while a fileplay back was pending.
    10. Modified the .connect command to default to the port specified by the
-       SF_Port configuration variable rather than 2074 for SF and RTP connections.
+       SF_Port configuration variable rather than 2074 for SF and RTP
+   connections.
    11. Corrected a bug in the .connect command that prevented a connection to
        a node by IP address from being reestablished immediately after it had
        been disconnected.
-   12. Modified Send2 to avoid using EchoLink sockets when Echolink is not enabled.
+   12. Modified Send2 to avoid using EchoLink sockets when Echolink is not
+   enabled.
    13. Modified GetPacketType to return PKT_TYPE_IGNORE for SF and RTP cleints
        with unknown codecs rather than kicking the connection.
    14. Corrected a bug in AuthorizedClient that prevented -R or -L stations from
@@ -291,11 +295,13 @@
    Revision 1.33  2008/02/09 17:03:12  wb6ymh
    1. Added support for a new configuration variable ShowStatusInInfo to
       enable EchoIRLP nodes to be configured to automatically show the name of
-      the current connection in the info field on the EchoLink directory servers.
+      the current connection in the info field on the EchoLink directory
+   servers.
 
    2. Added Echolink firewall mitigation code courtesy of Johnathan K1RFD.
       This code is invoked by the .connect command to assist with connections to
-      version 2.0 and above EchoLink nodes located behind unconfigured firewalls.
+      version 2.0 and above EchoLink nodes located behind unconfigured
+   firewalls.
 
    3. Added support for SFBind2IP to allow Speak Freely conferences to be bound
       to a different IP address than EchoLink conferences.
@@ -392,8 +398,8 @@
    8.  Modified GenSDES to only send the conference signature when thebridge is
        configured as a conference server.
    9.  Renamed the "quit" command to "quickexit" to prevent accidents.
-   10. Modified GetPacketType to allow duplicate commands to be entered via local
-       chat or command ports.
+   10. Modified GetPacketType to allow duplicate commands to be entered via
+   local chat or command ports.
 
    Revision 1.23  2006/08/05 23:30:04  wb6ymh
    Corrected warnings and errors with GCC 4.x.x.
@@ -411,11 +417,11 @@
    3. Added .refresh command.
    4. Added a "status" option to the .busy command.
    5. Modified RTP_Data to keep it from dumping Speak Freely clients on that
-      we started when the a packet with the wrong compression format is received.
-      This prevents problems staying connected to reflectors with misconfigured
-      clients.
-   6. Added patch from KF7FLY to improve the ability of EchoIRLP to track refused
-      outbound connections.
+      we started when the a packet with the wrong compression format is
+   received. This prevents problems staying connected to reflectors with
+   misconfigured clients.
+   6. Added patch from KF7FLY to improve the ability of EchoIRLP to track
+   refused outbound connections.
    7. Removed code that attempted to deal with an IP address changes for
       logged in clients.  The code had bugs and was just about impossible to
       test.  If your ISP randomly forces you to change your IP address it's
@@ -428,15 +434,15 @@
    10.Corrected bug in statistics gathering for the RxMBytesAllConf variable.
 
    Revision 1.20  2004/05/29 17:18:04  wb6ymh
-   1. Added a -p option to the .mute and .unmute commands to allow a station to be
-      muted or unmuted more persistently.  Normally when a station is explicitly
-      muted or unmuted the action applies current connection only.  If the station
-      disconnects and then reconnects he will return to the default mute state for
-      his station class.  The -p option causes the stations mute state to presist
-      across connections and disconnections as long as the station's callsign
-      remains in the directory cache.  This feature may be useful in certain
-      unusual circumstances when the a station class is muted, but there are
-      certain exceptions.
+   1. Added a -p option to the .mute and .unmute commands to allow a station to
+   be muted or unmuted more persistently.  Normally when a station is explicitly
+      muted or unmuted the action applies current connection only.  If the
+   station disconnects and then reconnects he will return to the default mute
+   state for his station class.  The -p option causes the stations mute state to
+   presist across connections and disconnections as long as the station's
+   callsign remains in the directory cache.  This feature may be useful in
+   certain unusual circumstances when the a station class is muted, but there
+   are certain exceptions.
 
    2. Corrected an infinite loop that occured when a "play4 -u ..." command was
       issued when a file was already playing for the specified user.
@@ -445,13 +451,14 @@
       well as PC users.
 
    4. Removed the code added in 0.70 that prevented the conference from
-      connecting to itself.  This feature caused problems for the EchoIRLP project.
+      connecting to itself.  This feature caused problems for the EchoIRLP
+   project.
 
    5. Corrected bug which caused the play4 pesudo user to timeout when the
       BlabOffTimer was enabled.
 
-   6. Added code to update the IP address of persistent clients when the client's
-      IP address changes in the directory.
+   6. Added code to update the IP address of persistent clients when the
+   client's IP address changes in the directory.
 
    Revision 1.19  2003/09/09 21:03:12  wb6ymh
    1. Changed the automute and autolurk logic to accomodate new EchoLink clients
@@ -496,12 +503,12 @@
    10. Modified code to pass local users SSRC on unmodified.  Previously local
        user's SSRC was changed to the SSRC of the conference for audio loop
        detection.
-   11. Added a ".play4" command that allows a recorded file to be played everyone
-       or a specified user.
-   12. Added -r, -c, -u, -s, -t, and -a options to the .mute and .unmute commands
-       to mute and unmute groups of stations with one command.  New stations
-       connecting to the conference will be muted automatically when a group
-       mute for their station type is in effect.
+   11. Added a ".play4" command that allows a recorded file to be played
+   everyone or a specified user.
+   12. Added -r, -c, -u, -s, -t, and -a options to the .mute and .unmute
+   commands to mute and unmute groups of stations with one command.  New
+   stations connecting to the conference will be muted automatically when a
+   group mute for their station type is in effect.
    13. Added ".busy" command to put the conference into a busy state.
    14. Added support for WelcomeDelay that specifies a delay between when the
        user connects and when the welcome file starts playing.
@@ -513,12 +520,13 @@
    16. Added support for the "StartupCmd" configuration file variable that
        provides the ability to execute commands automatically at startup.
    17. Modified snprintf usage to handle more flavors correctly. (The C99
-       standard defined the behaviour differently than earlier implementations.)d
+       standard defined the behaviour differently than earlier
+   implementations.)d
    18. Modified GenSDES() to parse "<conference name> (talker)" strings to pass
        on only the talker to prevent the line from growing at each hop.
    19. Added returned codes to all commands for command line interface.
-   20. Added carriage returns at the end of all strings generated by commands for
-       the command line interface.
+   20. Added carriage returns at the end of all strings generated by commands
+   for the command line interface.
    21. Added a ".message" command.
    22. Added the ability to .connect to a node by node number. Numeric arguments
        that do not contain dots are assumed to be node IDs.
@@ -529,7 +537,8 @@
        after 30 seconds. Previously this state was not cleared resulting in
        sysops receiving station lists from connected EchoLink conferences.
    26. Added the conference name to responses to commands issued with the .quote
-       command so that responses from multiple conferences can be differentiated.
+       command so that responses from multiple conferences can be
+   differentiated.
    27. Added code to prevent the conference from connecting to itself.
    28. Added code to automatically disconnect stations that send too many
        duplicate text messages.
@@ -592,7 +601,8 @@
    Revision 1.11  2002/11/02 19:04:26  wb6ymh
    1. Removed BannedStations, SaveBanedList(), LoadBannedList(), and
       FreeBannedList(). These have been replaced with new ACL routines.
-   2. Added routines to convert between Speak Freely, RTP and EchoLink protocols.
+   2. Added routines to convert between Speak Freely, RTP and EchoLink
+   protocols.
    3. Added support for a Speak Freely and RTP conference.
    4. Added code to check connecting clients against ACL and EchoLink directory
       servers.
@@ -640,17 +650,19 @@
        command.
 
    Revision 1.9  2002/09/19 22:48:56  wb6ymh
-   1. Modified GetCall() to protect against (invalid) RTCP_SDES blocks that don't
-      terminate with a RTCP_SDES_END item.  This was causing page faults in the
-      Windows version, but didn't appear to effect the *nix versions.
-   2. Modified RTP_Rx() to only forward audio packet to clients with bInConf set.
+   1. Modified GetCall() to protect against (invalid) RTCP_SDES blocks that
+   don't terminate with a RTCP_SDES_END item.  This was causing page faults in
+   the Windows version, but didn't appear to effect the *nix versions.
+   2. Modified RTP_Rx() to only forward audio packet to clients with bInConf
+   set.
 
    Revision 1.8  2002/09/15 15:03:48  wb6ymh
    1.  Added new administrator commands .connect and .disconnect.
    2.  Added additional statistics to the .stats command.
    3.  Added support for the Echolink client's "Request version Information"
        packet.
-   4.  Added configuration file variables to set the contents of the banner area.
+   4.  Added configuration file variables to set the contents of the banner
+   area.
    5.  Added configruation file variables to allow current and maximum user
        counts to added to the location string and conference ID line.
    6.  Added new user command .stop to allow bulletin playback to be terminated
@@ -684,11 +696,13 @@
    1.  Added new administrator commands .admin, .admins, .record, .list, .mute,
       .kick, .ban, and .info.
    2.  Added new user commands .list, .play, .stats and .debug.
-   3.  Modified the station list so that new stations enter at the top of the list.
+   3.  Modified the station list so that new stations enter at the top of the
+   list.
    4.  Modified the station list so the station talking is always displayed.
    5.  Added total number of connected stations to top of station list.
    6.  Added code to send a warning message to stations that double.
-   7.  Modified all log entries to use %m for error message display when available.
+   7.  Modified all log entries to use %m for error message display when
+   available.
    8.  Added amount to time client was connected to log entries.
    9.  Added code to track the number of open sockets.
    10. Modified GetCall() to compress mutiple spaces between callsign and user's
@@ -722,70 +736,70 @@
 #include "common.h"
 
 #ifndef _WIN32
-   // FreeBSD, Linux, etc..
-   #include <stdio.h>
-   #include <stdlib.h>
-   #include <sys/types.h>
-   #ifdef TIME_WITH_SYS_TIME
-      #include <sys/time.h>
-      #include <time.h>
-   #else
-      #ifdef HAVE_SYS_TIME_H
-         #include <sys/time.h>
-      #else
-         #include <time.h>
-      #endif
-   #endif
-   #include <unistd.h>
-   #include <sys/socket.h>
-   #include <netinet/in.h>
-   #include <arpa/inet.h>
-   #include <errno.h>
-   #include <string.h>
-#ifdef HAVE_FCNTL_H
-   #include <fcntl.h>
-#endif
-   #include <netdb.h>
-   #include <ctype.h>
-   #ifdef HAVE_SYS_TIMEB_H
-      #include <sys/timeb.h>
-   #endif
-   #include <sys/stat.h>
-   #include <stdarg.h>
+// FreeBSD, Linux, etc..
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#ifdef TIME_WITH_SYS_TIME
+#include <sys/time.h>
+#include <time.h>
 #else
-   // Windoze
-   #include <stdio.h>
-   #include <time.h>
-   #include <io.h>
-   #include <winsock2.h>
-   #include <sys\timeb.h>
-   #include <ctype.h>
-   #include <sys\stat.h>
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#else
+#include <time.h>
+#endif
+#endif
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <ctype.h>
+#include <netdb.h>
+#ifdef HAVE_SYS_TIMEB_H
+#include <sys/timeb.h>
+#endif
+#include <stdarg.h>
+#include <sys/stat.h>
+#else
+// Windoze
+#include <ctype.h>
+#include <io.h>
+#include <stdio.h>
+#include <sys\stat.h>
+#include <sys\timeb.h>
+#include <time.h>
+#include <winsock2.h>
 #endif
 
 // Use a non-case sensitive compare function if one is available
 #ifdef HAVE_STRICMP
-   #define STRCMP stricmp
+#define STRCMP stricmp
 #else
 #ifdef HAVE_STRCASECMP
-   #define STRCMP strcasecmp
+#define STRCMP strcasecmp
 #else
-   #define STRCMP strcmp
+#define STRCMP strcmp
 #endif
 #endif
 
 #include "avl.h"
-#include "main.h"
+#include "conference.h"
 #include "configvars.h"
 #include "dirclient.h"
-#include "rtp.h"
-#include "users.h"
-#include "conference.h"
-#include "ilink.h"
-#include "sf.h"
 #include "hostfile.h"
-#include "zlib.h"
+#include "ilink.h"
+#include "main.h"
+#include "rtp.h"
+#include "sf.h"
 #include "tbd.h"
+#include "users.h"
+#include "zlib.h"
 
 #if defined _WIN32GUI || defined _X11GUI
 #include "tbdthread_common.h"
@@ -793,41 +807,40 @@
 
 #include "eventhook.h"
 
-#ifdef   LINK_BOX
-   #include "linkbox.h"
-   #define TBDCMD    "tlbcmd"
-   #define TBDCHAT   "tlbchat"
+#ifdef LINK_BOX
+#include "linkbox.h"
+#define TBDCMD "tlbcmd"
+#define TBDCHAT "tlbchat"
 #else
-   #define EndPointInit() 0
-   #define EndPoint(x,y,z)
-   #define TBDCMD    "tbdcmd"
-   #define TBDCHAT   "tbdchat"
+#define EndPointInit() 0
+#define EndPoint(x, y, z)
+#define TBDCMD "tbdcmd"
+#define TBDCHAT "tbdchat"
 #endif
 
 #ifdef USE_DMALLOC
 #include "dmalloc.h"
 #endif
 
-#define  HEADER_OVERHEAD   28    // 20 byte IP header + 8 byte UDP header
-#define  INFO_EXTENSION    ".info"
+#define HEADER_OVERHEAD 28 // 20 byte IP header + 8 byte UDP header
+#define INFO_EXTENSION ".info"
 
-#define  FDUPLEX_TEXT   "\003dpx1"
+#define FDUPLEX_TEXT "\003dpx1"
 
 /* Macros for min/max. */
 #ifndef MIN
-#define  MIN(a,b) (((a)<(b))?(a):(b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #ifndef MAX
-#define  MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
-
 typedef struct Bulletin_TAG {
-   struct Bulletin_TAG *Link;
-   char *Filename;
-   char *Description;
-   char *RunTime;
+  struct Bulletin_TAG *Link;
+  char *Filename;
+  char *Description;
+  char *RunTime;
 } Bulletin;
 
 Bulletin *BulletinList;
@@ -836,7 +849,7 @@ Bulletin *BulletinListTail;
 ConfClient *ClientTalking = NULL;
 ConfClient *LastTalker = NULL;
 
-const char *CallSignString   = "CALLSIGN";
+const char *CallSignString = "CALLSIGN";
 
 char StatusMsg[512];
 int StatusMsgLen = 0;
@@ -865,7 +878,7 @@ int LastRcode;
 int ZeroSSRC;
 char *LastCmdText;
 char *LastCmd;
-char ConnectedStatus[MAX_QTH_LEN+1];
+char ConnectedStatus[MAX_QTH_LEN + 1];
 
 int bConferenceBusy = FALSE;
 
@@ -877,7 +890,6 @@ int RxMBytesAllConf = 0;
 
 char *StationDisconnected = NULL;
 
-
 ProtoData gProtoData[NUM_PROTOCOLS];
 
 ConfClient CmdLineCC;
@@ -888,2061 +900,1947 @@ int bCmdLineChatMode;
 char *CmdArg;
 int bLogCmd;
 
-struct avl_table *Conferences;   // sorted by Port number
+struct avl_table *Conferences; // sorted by Port number
 
-void ConvertRTP2iLink(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream);
-void ConvertiLink2RTP(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream);
-void ConvertSF2iLink(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream);
-void ConvertiLink2SF(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream);
-void ConvertiLink2Ast(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream);
-void OpenAudioFile(ConfClient *pCC,char *Filename, char *Mode);
-void StartPlayback(ClientInfo *p,ConfClient *pCC);
-int FileRecord(ClientInfo *p,ConfClient *pCC,EventType Event);
-int DuplicateTextMsg(ClientInfo *p,ConfClient *pCC);
+void ConvertRTP2iLink(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream);
+void ConvertiLink2RTP(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream);
+void ConvertSF2iLink(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream);
+void ConvertiLink2SF(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream);
+void ConvertiLink2Ast(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream);
+void OpenAudioFile(ConfClient *pCC, char *Filename, char *Mode);
+void StartPlayback(ClientInfo *p, ConfClient *pCC);
+int FileRecord(ClientInfo *p, ConfClient *pCC, EventType Event);
+int DuplicateTextMsg(ClientInfo *p, ConfClient *pCC);
 
-typedef void (*ConversionF)(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream);
+typedef void (*ConversionF)(ProtoData *pPDat, char *inBuf, int inLen,
+                            int bNewStream);
 
-ConversionF ProtoConvert[NUM_PROTOCOLS][NUM_PROTOCOLS] = 
-{
-   {NULL,            // From Speak Freely to Speak Freely
-   NULL,             // From Speak Freely to RTP
-   ConvertSF2iLink}, // From Speak Freely to ILink
+ConversionF ProtoConvert[NUM_PROTOCOLS][NUM_PROTOCOLS] = {
+    {NULL,             // From Speak Freely to Speak Freely
+     NULL,             // From Speak Freely to RTP
+     ConvertSF2iLink}, // From Speak Freely to ILink
 
-   {NULL,            // From RTP to Speak Freely
-   NULL,             // From RTP to RTP
-   ConvertRTP2iLink},// From RTP to ILink
+    {NULL,              // From RTP to Speak Freely
+     NULL,              // From RTP to RTP
+     ConvertRTP2iLink}, // From RTP to ILink
 
-   {ConvertiLink2SF, // From iLink to SF
-   ConvertiLink2RTP, // From ilink to RTP
-   NULL},            // From iLink to iLink
+    {ConvertiLink2SF,  // From iLink to SF
+     ConvertiLink2RTP, // From ilink to RTP
+     NULL},            // From iLink to iLink
 };
 
-#define DUP_TRACKING_TIMEOUT  10 // 10 seconds
-#define MAX_DUP_TRACKING      32
+#define DUP_TRACKING_TIMEOUT 10 // 10 seconds
+#define MAX_DUP_TRACKING 32
 typedef struct {
-   unsigned short crc;
-   time_t   TimeStamp;
-   int      bLogged:1;
-   char     FirstFrom[MAX_CALL_LEN+1];
+  unsigned short crc;
+  time_t TimeStamp;
+  int bLogged : 1;
+  char FirstFrom[MAX_CALL_LEN + 1];
 } DupTrackingEntry;
 
 DupTrackingEntry DupTracking[MAX_DUP_TRACKING];
 
-int ConfCompare(const void *avl_a,const void *avl_b,void *avl_param);
-int CClientCompare(const void *avl_a,const void *avl_b,void *avl_param);
+int ConfCompare(const void *avl_a, const void *avl_b, void *avl_param);
+int CClientCompare(const void *avl_a, const void *avl_b, void *avl_param);
 ConfClient *CreateNewConfClient(void);
 void RemoveFromStationList(ConfClient *pCC);
 void DeleteCClient(ConfClient *pCC);
 char CheckRTCP(ConfServer *pCS);
-int GetCall(ConfServer *pCS,ConfClient *pCC,rtcp_t *p,int len);
+int GetCall(ConfServer *pCS, ConfClient *pCC, rtcp_t *p, int len);
 char *GetLocalIPAdr(void);
-int GenBye(ConfClient *pCC,char *Temp,char *Reason);
+int GenBye(ConfClient *pCC, char *Temp, char *Reason);
 void SendStationList(ConfServer *pCS);
 void SetTimeoutRTCP(ClientInfo *p);
-void ConferenceCmd(ClientInfo *p,ConfClient *pCC,char *cmd);
+void ConferenceCmd(ClientInfo *p, ConfClient *pCC, char *cmd);
 int TimeLapse(struct timeval *p);
-void CmdHelp(ClientInfo *p,ConfClient *pCC1,char *Arg);
+void CmdHelp(ClientInfo *p, ConfClient *pCC1, char *Arg);
 int FilePlayBack(ClientInfo *p);
-void SendBuf2(ClientInfo *p,ConfClient *pCC,int bControLPort);
-void CalcBW(ConfServer *pCS,int bClear);
-void CmdVersion(ClientInfo *p,ConfClient *pCC1,char *Arg);
-void SendToAllSysops(ClientInfo *p,ConfServer *pCS);
-void SendSDES(ConfServer *pCS,ConfClient *pCC);
-void ConvertProtocol(ProtoData *pProtoDat,Protocol InputProto,
-                     Protocol OutputProto,int bNewStream);
-PacketType GetPacketType(ClientInfo *p,ConfClient *pCC);
-int FromUs(ClientInfo *p,ConfClient *pCC);
-int AuthorizedClient(ClientInfo *p,ConfClient *pCC);
-void SaveBadPacket(ClientInfo *p,char *Filename);
+void SendBuf2(ClientInfo *p, ConfClient *pCC, int bControLPort);
+void CalcBW(ConfServer *pCS, int bClear);
+void CmdVersion(ClientInfo *p, ConfClient *pCC1, char *Arg);
+void SendToAllSysops(ClientInfo *p, ConfServer *pCS);
+void SendSDES(ConfServer *pCS, ConfClient *pCC);
+void ConvertProtocol(ProtoData *pProtoDat, Protocol InputProto,
+                     Protocol OutputProto, int bNewStream);
+PacketType GetPacketType(ClientInfo *p, ConfClient *pCC);
+int FromUs(ClientInfo *p, ConfClient *pCC);
+int AuthorizedClient(ClientInfo *p, ConfClient *pCC);
+void SaveBadPacket(ClientInfo *p, char *Filename);
 void SendFirewallOpenRequest(ConfServer *pCS, ConfClient *pCC);
 char *FirstChatChar(char *Buf);
-void SendChatEvent(char *Type,char *Buf);
+void SendChatEvent(char *Type, char *Buf);
 
-int CreateServerClient(ConfServer *pCS,int Port,int bLocal,ClientInfo **pRet)
-{
-   IPAdrUnion MyAdr;
-   ClientInfo *pClient;
-   int On = 1;
-   int Err = 0;   // assume the best
-   int bEchoLinkPort = (Port == ILINK_RTP_PORT || Port == ILINK_RTCP_PORT);
+int CreateServerClient(ConfServer *pCS, int Port, int bLocal,
+                       ClientInfo **pRet) {
+  IPAdrUnion MyAdr;
+  ClientInfo *pClient;
+  int On = 1;
+  int Err = 0; // assume the best
+  int bEchoLinkPort = (Port == ILINK_RTP_PORT || Port == ILINK_RTCP_PORT);
 
-   for( ; ; ) {
-      pClient = CreateNewClient();
-      if(pClient == NULL) {
-         LOG_ERROR(("CreateServerClient(): CreateNewClient failed.\n"));
-         Err = ERR_MALLOC;
-         break;
-      }
+  for (;;) {
+    pClient = CreateNewClient();
+    if (pClient == NULL) {
+      LOG_ERROR(("CreateServerClient(): CreateNewClient failed.\n"));
+      Err = ERR_MALLOC;
+      break;
+    }
 
-      memset(&MyAdr,0,sizeof(MyAdr));
-      if(bLocal) {
+    memset(&MyAdr, 0, sizeof(MyAdr));
+    if (bLocal) {
       // listen to localhost port only
-         MyAdr.ADDR = inet_addr("127.0.0.1");
+      MyAdr.ADDR = inet_addr("127.0.0.1");
+    } else if (Bind2IP != NULL && (SFBind2IP == NULL || bEchoLinkPort)) {
+      MyAdr.ADDR = inet_addr(Bind2IP);
+      if (MyAdr.ADDR == INADDR_NONE) {
+        LOG_ERROR(("CreateServerClient(): failed to convert \"%s\" to IP "
+                   "address.\n",
+                   Bind2IP));
+        Err = ERR_BIND_IP;
+        break;
+      } else {
+        LOG_ERROR(("Port %d bound to %s.\n", Port, Bind2IP));
       }
-      else if(Bind2IP != NULL && (SFBind2IP == NULL || bEchoLinkPort)) {
-          MyAdr.ADDR = inet_addr(Bind2IP);
-          if(MyAdr.ADDR == INADDR_NONE) {
-             LOG_ERROR(("CreateServerClient(): failed to convert \"%s\" to IP "
-                        "address.\n",Bind2IP));
-             Err = ERR_BIND_IP;
-             break;
-          }
-          else {
-              LOG_ERROR(("Port %d bound to %s.\n",Port,Bind2IP));
-          }
+    } else if (SFBind2IP != NULL && !bEchoLinkPort) {
+      MyAdr.ADDR = inet_addr(SFBind2IP);
+      if (MyAdr.ADDR == INADDR_NONE) {
+        LOG_ERROR(("CreateServerClient(): failed to convert \"%s\" to IP "
+                   "address.\n",
+                   Bind2IP));
+        Err = ERR_BIND_IP;
+        break;
+      } else {
+        LOG_ERROR(("Binding port %d to %s.\n", Port, SFBind2IP));
       }
-      else if(SFBind2IP != NULL && !bEchoLinkPort) {
-         MyAdr.ADDR = inet_addr(SFBind2IP);
-         if(MyAdr.ADDR == INADDR_NONE) {
-            LOG_ERROR(("CreateServerClient(): failed to convert \"%s\" to IP "
-                       "address.\n",Bind2IP));
-            Err = ERR_BIND_IP;
-            break;
-         }
-         else {
-             LOG_ERROR(("Binding port %d to %s.\n",Port,SFBind2IP));
-         }
-      }
-      else {
-         MyAdr.ADDR = INADDR_ANY;
-      }
+    } else {
+      MyAdr.ADDR = INADDR_ANY;
+    }
 
-      SET_WAIT4_RD(pClient);
-      pClient->p = pCS;
-      pClient->BufSize = CONF_BUF_SIZE;
-      pClient->Buf = malloc(pClient->BufSize);
+    SET_WAIT4_RD(pClient);
+    pClient->p = pCS;
+    pClient->BufSize = CONF_BUF_SIZE;
+    pClient->Buf = malloc(pClient->BufSize);
 
-      pClient->Socket = socket(AF_INET,SOCK_DGRAM,0);
-      if(pClient->Socket == SOCKET_ERROR) {
-         Err = ERROR_CODE;
-         LOG_ERROR(("CreateServerClient(): Socket() failed, %s",
-                    Err2String(Err)));
-         break;
-      }
-
-      OpenSockets++;
-      MyAdr.i.sin_family = AF_INET;
-      MyAdr.PORT = htons((unsigned short) Port);
-      pClient->HisAdr = MyAdr;
-      avl_insert(ClientTree,pClient);
-      pClient->bInClientTree = TRUE;
-
-      if(setsockopt(pClient->Socket,SOL_SOCKET,SO_REUSEADDR,(char *) &On,
-                    sizeof(On)) == -1) 
-      {
-         Err = ERROR_CODE;
-         LOG_ERROR(("CreateServerClient(): setsockopt() failed %s",
-                    Err2String(ERROR_CODE)));
-         break;
-      }
-
-      if(bind(pClient->Socket,&MyAdr.s,sizeof(MyAdr)) == SOCKET_ERROR) {
-         Err = ERROR_CODE;
-         LOG_ERROR(("CreateServerClient(): bind() failed for %s:%d %s",
-                    inet_ntoa(MyAdr.i.sin_addr),Port,Err2String(ERROR_CODE)));
-      }
+    pClient->Socket = socket(AF_INET, SOCK_DGRAM, 0);
+    if (pClient->Socket == SOCKET_ERROR) {
+      Err = ERROR_CODE;
+      LOG_ERROR(("CreateServerClient(): Socket() failed, %s", Err2String(Err)));
       break;
-   }
+    }
 
-   if(Err == 0) {
-      *pRet = pClient;
-   }
-   else if(pClient != NULL) {
-      DeleteClient(pClient);
-   }
+    OpenSockets++;
+    MyAdr.i.sin_family = AF_INET;
+    MyAdr.PORT = htons((unsigned short)Port);
+    pClient->HisAdr = MyAdr;
+    avl_insert(ClientTree, pClient);
+    pClient->bInClientTree = TRUE;
 
-   return Err;
+    if (setsockopt(pClient->Socket, SOL_SOCKET, SO_REUSEADDR, (char *)&On,
+                   sizeof(On)) == -1) {
+      Err = ERROR_CODE;
+      LOG_ERROR(("CreateServerClient(): setsockopt() failed %s",
+                 Err2String(ERROR_CODE)));
+      break;
+    }
+
+    if (bind(pClient->Socket, &MyAdr.s, sizeof(MyAdr)) == SOCKET_ERROR) {
+      Err = ERROR_CODE;
+      LOG_ERROR(("CreateServerClient(): bind() failed for %s:%d %s",
+                 inet_ntoa(MyAdr.i.sin_addr), Port, Err2String(ERROR_CODE)));
+    }
+    break;
+  }
+
+  if (Err == 0) {
+    *pRet = pClient;
+  } else if (pClient != NULL) {
+    DeleteClient(pClient);
+  }
+
+  return Err;
 }
 
+void DestroyCC(void *avl_item, void *avl_param) {
+  ConfClient *pCC = (ConfClient *)avl_item;
 
-void DestroyCC(void *avl_item, void *avl_param)
-{
-   ConfClient *pCC = (ConfClient *) avl_item;
-
-   DeleteCClient(pCC);
+  DeleteCClient(pCC);
 }
 
-void DeleteConf(ConfServer *pCS)
-{
-   LOG_NORM(("Deleting conference for port %d.\n",pCS->AudioPort));
-   if(avl_delete(Conferences,pCS) == NULL) {
-      LOG_ERROR(("DeleteConf: avl_delete() failed to find client.\n"));
-   }
+void DeleteConf(ConfServer *pCS) {
+  LOG_NORM(("Deleting conference for port %d.\n", pCS->AudioPort));
+  if (avl_delete(Conferences, pCS) == NULL) {
+    LOG_ERROR(("DeleteConf: avl_delete() failed to find client.\n"));
+  }
 
-   if(pCS->pAudio != NULL) {
-      pCS->pAudio->p = NULL;
-      DeleteClient(pCS->pAudio);
-   }
+  if (pCS->pAudio != NULL) {
+    pCS->pAudio->p = NULL;
+    DeleteClient(pCS->pAudio);
+  }
 
-   if(pCS->pControl != NULL) {
-      pCS->pControl->p = NULL;
-      DeleteClient(pCS->pControl);
-   }
+  if (pCS->pControl != NULL) {
+    pCS->pControl->p = NULL;
+    DeleteClient(pCS->pControl);
+  }
 
-   if(pCS->fp != NULL) {
-      fclose(pCS->fp);
-   }
+  if (pCS->fp != NULL) {
+    fclose(pCS->fp);
+  }
 
-   if(!pCS->bSlaveConf && pCS->ConfTree != NULL) {
-      avl_destroy(pCS->ConfTree,NULL);
-   }
+  if (!pCS->bSlaveConf && pCS->ConfTree != NULL) {
+    avl_destroy(pCS->ConfTree, NULL);
+  }
 
-   free(pCS);
+  free(pCS);
 }
 
-int CreateConference(
-   int AudioPort,
-   ConfServer *pMainConf,
-   ConfServer **pRet)
-{
-   ConfServer *pCS;
-   int Err = 0;   // assume good things
+int CreateConference(int AudioPort, ConfServer *pMainConf, ConfServer **pRet) {
+  ConfServer *pCS;
+  int Err = 0; // assume good things
 
-   for(; ; ) {
-      if((pCS = (ConfServer *) malloc(sizeof(ConfServer))) == NULL) {
-         LOG_ERROR(("CreateConference(): malloc failed.\n"));
-         Err = ERR_MALLOC;
-         break;
-      }
-      memset(pCS,0,sizeof(ConfServer));
-      avl_insert(Conferences,pCS);
-      pCS->AudioPort = AudioPort;
+  for (;;) {
+    if ((pCS = (ConfServer *)malloc(sizeof(ConfServer))) == NULL) {
+      LOG_ERROR(("CreateConference(): malloc failed.\n"));
+      Err = ERR_MALLOC;
+      break;
+    }
+    memset(pCS, 0, sizeof(ConfServer));
+    avl_insert(Conferences, pCS);
+    pCS->AudioPort = AudioPort;
 
-      if(pMainConf == NULL) {
-         pCS->ConfTree = avl_create(CClientCompare,pCS,NULL);
-         pCS->pLastAudioIn = &pCS->LastAudioIn;
-         pCS->pMasterCS = pCS;
-         pCS->CompressionType = CompressionType;
-      }
-      else {
-         pCS->bSlaveConf = TRUE;
-         pCS->pMasterCS = pMainConf;
-         pCS->ConfTree = pMainConf->ConfTree;
-         pCS->pLastAudioIn = &pMainConf->LastAudioIn;
-         pCS->CompressionType = pMainConf->CompressionType;
-      }
+    if (pMainConf == NULL) {
+      pCS->ConfTree = avl_create(CClientCompare, pCS, NULL);
+      pCS->pLastAudioIn = &pCS->LastAudioIn;
+      pCS->pMasterCS = pCS;
+      pCS->CompressionType = CompressionType;
+    } else {
+      pCS->bSlaveConf = TRUE;
+      pCS->pMasterCS = pMainConf;
+      pCS->ConfTree = pMainConf->ConfTree;
+      pCS->pLastAudioIn = &pMainConf->LastAudioIn;
+      pCS->CompressionType = pMainConf->CompressionType;
+    }
 
-      if(pCS->ConfTree == NULL) {
-         LOG_ERROR(("CreateConference(): avl_create failed.\n"));
-         Err = ERR_AVL_CREATE;
-         break;
-      }
+    if (pCS->ConfTree == NULL) {
+      LOG_ERROR(("CreateConference(): avl_create failed.\n"));
+      Err = ERR_AVL_CREATE;
+      break;
+    }
 
-      if(bEchoLinkEnabled || AudioPort != ILINK_RTP_PORT) {
+    if (bEchoLinkEnabled || AudioPort != ILINK_RTP_PORT) {
       // Don't open ILINK_RTP_PORT unless EchoLink mode is enabled
-         if((Err = CreateServerClient(pCS,AudioPort,FALSE,&pCS->pAudio)) != 0) {
-            break;
-         }
-
-         Err = CreateServerClient(pCS,AudioPort+1,FALSE,&pCS->pControl);
+      if ((Err = CreateServerClient(pCS, AudioPort, FALSE, &pCS->pAudio)) !=
+          0) {
+        break;
       }
-      break;
-   }
 
-   if(Err == 0) {
-      *pRet = pCS;
-      if(AudioPort == ILINK_RTP_PORT) {
-         pCS->biLinkConf = TRUE;
-      }
-   }
-   else if(pCS != NULL) {
-      DeleteConf(pCS);
-   }
+      Err = CreateServerClient(pCS, AudioPort + 1, FALSE, &pCS->pControl);
+    }
+    break;
+  }
 
-   return Err;
+  if (Err == 0) {
+    *pRet = pCS;
+    if (AudioPort == ILINK_RTP_PORT) {
+      pCS->biLinkConf = TRUE;
+    }
+  } else if (pCS != NULL) {
+    DeleteConf(pCS);
+  }
+
+  return Err;
 }
-
 
 // Rtp_port = 0   // disable
 // Rtp_port = <evenport>
 // Rtp_port = <evenport>-<oddport> for a range
-int RtpInit()
-{
-   int Ret = ERR_CONFIG_FILE; // assume the worse
-   char *cp;
-   int FirstPort;
-   int LastPort;
-   int i;
-   int Err;
-   ConfServer *pCS;
-   ConfServer ConfLookup;
+int RtpInit() {
+  int Ret = ERR_CONFIG_FILE; // assume the worse
+  char *cp;
+  int FirstPort;
+  int LastPort;
+  int i;
+  int Err;
+  ConfServer *pCS;
+  ConfServer ConfLookup;
 
-   do {
-      if((cp = strchr(RTP_Port,'-')) != NULL) {
+  do {
+    if ((cp = strchr(RTP_Port, '-')) != NULL) {
       // Range
-         *cp++ = 0;
-      }
+      *cp++ = 0;
+    }
 
-      if(sscanf(RTP_Port,"%d",&FirstPort) != 1) {
-         LOG_ERROR(("Error:  Invalid RTP_Port \"%s\"\n",RTP_Port));
-         break;
-      }
-      else if(FirstPort & 1) {
-         LOG_ERROR(("Error: First RTP port must be even\n"));
-         break;
-      }
+    if (sscanf(RTP_Port, "%d", &FirstPort) != 1) {
+      LOG_ERROR(("Error:  Invalid RTP_Port \"%s\"\n", RTP_Port));
+      break;
+    } else if (FirstPort & 1) {
+      LOG_ERROR(("Error: First RTP port must be even\n"));
+      break;
+    }
 
-      if(cp == NULL) {
+    if (cp == NULL) {
       // Single port
-         LastPort = FirstPort + 1;
-      }
-      else {
+      LastPort = FirstPort + 1;
+    } else {
       // Range
-         if(sscanf(cp,"%d",&LastPort) != 1) {
-            *cp = '-';
-            LOG_ERROR(("Error: Invalid RTP_Port \"%s\"\n",RTP_Port));
-            break;
-         }
-         else if(!(LastPort & 1)) {
-            LOG_ERROR(("Error: Last RTP port must be odd\n"));
-            break;
-         }
-         else if(LastPort <= FirstPort) {
-            LOG_ERROR(("Error: The last port must larger the first port\n"));
-            break;
-         }
+      if (sscanf(cp, "%d", &LastPort) != 1) {
+        *cp = '-';
+        LOG_ERROR(("Error: Invalid RTP_Port \"%s\"\n", RTP_Port));
+        break;
+      } else if (!(LastPort & 1)) {
+        LOG_ERROR(("Error: Last RTP port must be odd\n"));
+        break;
+      } else if (LastPort <= FirstPort) {
+        LOG_ERROR(("Error: The last port must larger the first port\n"));
+        break;
+      }
+    }
+
+    for (i = FirstPort; i < LastPort; i += 2) {
+      ConfLookup.AudioPort = i;
+
+      if ((pCS = (ConfServer *)avl_find(Conferences, &ConfLookup)) == NULL) {
+        // need to create the conference
+        if (LinkConferences) {
+          Err = CreateConference(i, piLinkConf, &pCS);
+        } else {
+          Err = CreateConference(i, NULL, &pCS);
+        }
+
+        if (Err != 0) {
+          LOG_ERROR(("Error: Couldn't open port (%d)\r", i));
+          break;
+        } else {
+          LOG_ERROR(("Created RTP conference for port %d\n", i));
+          pCS->bRTPConf = TRUE;
+          pCS->pAudio->State = RTP_Handler;
+          pCS->pControl->State = RTCP_Handler;
+          pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
+
+          if (piLinkConf->pAudio == NULL) {
+            piLinkConf->pAudio = pCS->pAudio;
+            piLinkConf->pControl = pCS->pControl;
+          }
+        }
       }
 
-      for(i = FirstPort; i < LastPort; i += 2) {
-         ConfLookup.AudioPort = i;
+      Ret = 0;
+    }
+  } while (FALSE);
 
-         if((pCS = (ConfServer *) avl_find(Conferences,&ConfLookup)) == NULL) {
-         // need to create the conference
-            if(LinkConferences) {
-               Err = CreateConference(i,piLinkConf,&pCS);
-            }
-            else {
-               Err = CreateConference(i,NULL,&pCS);
-            }
-
-            if(Err != 0) {
-               LOG_ERROR(("Error: Couldn't open port (%d)\r",i));
-               break;
-            }
-            else {
-               LOG_ERROR(("Created RTP conference for port %d\n",i));
-               pCS->bRTPConf = TRUE;
-               pCS->pAudio->State = RTP_Handler;
-               pCS->pControl->State = RTCP_Handler;
-               pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
-
-               if(piLinkConf->pAudio == NULL) {
-                  piLinkConf->pAudio = pCS->pAudio;
-                  piLinkConf->pControl= pCS->pControl;
-               }
-            }
-         }
-
-         Ret = 0;
-      }
-   } while(FALSE);
-
-   return Ret;
+  return Ret;
 }
 
 // Init iLink/EchoLink conference
-int ConferenceInit()
-{
-   time_t Time = time(NULL);
-   int Err = 0;   // Assume good things
-   ClientInfo *pClient;
+int ConferenceInit() {
+  time_t Time = time(NULL);
+  int Err = 0; // Assume good things
+  ClientInfo *pClient;
 
-   do {
-      Conferences = avl_create(ConfCompare,NULL,NULL);
-      
-      Err = CreateConference(ILINK_RTP_PORT,NULL,&piLinkConf);
+  do {
+    Conferences = avl_create(ConfCompare, NULL, NULL);
 
-      if(Err != 0 || piLinkConf == NULL) {
-         break;
-      }
+    Err = CreateConference(ILINK_RTP_PORT, NULL, &piLinkConf);
 
-      if(RTP_Port != NULL) {
-         Err = RtpInit();
-      }
+    if (Err != 0 || piLinkConf == NULL) {
+      break;
+    }
 
-#ifdef   LINK_BOX
-      if((Err = EndPointInit()) != 0) {
-         break;
-      }
+    if (RTP_Port != NULL) {
+      Err = RtpInit();
+    }
+
+#ifdef LINK_BOX
+    if ((Err = EndPointInit()) != 0) {
+      break;
+    }
 #endif
 
-      if(CmdPort != 0) {
-         if((Err = CreateServerClient(piLinkConf,CmdPort,TRUE,&pClient)) != 0) {
-            break;
-         }
-         CmdClient = pClient;
-         pClient->State = CmdLine_Handler;
-         CmdLineCC.pCS = piLinkConf;
-         CmdLineCC.bCmdLine = TRUE;
-         CmdLineCC.bSysop = TRUE;
-         CmdLineCC.bAdmin = TRUE;
-         CmdLineCC.Callsign = TBDCMD;
-         CmdLineCC.CallPlus = CmdLineCC.Callsign;
-         CmdLineCC.Proto = PROTO_ILINK;
+    if (CmdPort != 0) {
+      if ((Err = CreateServerClient(piLinkConf, CmdPort, TRUE, &pClient)) !=
+          0) {
+        break;
       }
+      CmdClient = pClient;
+      pClient->State = CmdLine_Handler;
+      CmdLineCC.pCS = piLinkConf;
+      CmdLineCC.bCmdLine = TRUE;
+      CmdLineCC.bSysop = TRUE;
+      CmdLineCC.bAdmin = TRUE;
+      CmdLineCC.Callsign = TBDCMD;
+      CmdLineCC.CallPlus = CmdLineCC.Callsign;
+      CmdLineCC.Proto = PROTO_ILINK;
+    }
 
-      if(bEchoLinkEnabled) {
+    if (bEchoLinkEnabled) {
       // EchoLink enabled
-         piLinkConf->pAudio->State = RTP_Handler;
-         piLinkConf->pControl->State = RTCP_Handler;
-         if(LoginInterval > 0) {
-         // EchoLink directory server access enabled
-            NextLoginTime = Time + 60; // wait a minute before the second login
-            if(StationListInterval > 0) {
-               NextStationListTime = Time + StationListInterval;
-            }
-            else {
-               NextStationListTime = 0;
-            }
-            if(AvrsEnable) {
-               NextAVRSTime = Time;
-            }
-            piLinkConf->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
-            if(StationListInterval > 0) {
-            // Get initial station list
-               ServerRequest(SERV_REQ_LOGIN_AND_LIST,0,NULL);
-            }
-            else {
-            // Do initial login
-               ServerRequest(SERV_REQ_LOGIN,0,NULL);
-            }
-            SetTimeoutRTCP(piLinkConf->pControl);
-         }
-
-         if(ChatPort!= 0) {
-            if((Err = CreateServerClient(piLinkConf,ChatPort,TRUE,&pClient)) != 0) {
-               break;
-            }
-            ChatClient = pClient;
-            pClient->State = CmdLine_Handler;
-            ChatCC.pCS = piLinkConf;
-            ChatCC.bCmdLine = TRUE;
-            ChatCC.bSysop = TRUE;
-            ChatCC.bAdmin = TRUE;
-            ChatCC.Callsign = TBDCHAT;
-            ChatCC.CallPlus = ChatCC.Callsign;
-            ChatCC.Proto = PROTO_ILINK;
-         }
+      piLinkConf->pAudio->State = RTP_Handler;
+      piLinkConf->pControl->State = RTCP_Handler;
+      if (LoginInterval > 0) {
+        // EchoLink directory server access enabled
+        NextLoginTime = Time + 60; // wait a minute before the second login
+        if (StationListInterval > 0) {
+          NextStationListTime = Time + StationListInterval;
+        } else {
+          NextStationListTime = 0;
+        }
+        if (AvrsEnable) {
+          NextAVRSTime = Time;
+        }
+        piLinkConf->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
+        if (StationListInterval > 0) {
+          // Get initial station list
+          ServerRequest(SERV_REQ_LOGIN_AND_LIST, 0, NULL);
+        } else {
+          // Do initial login
+          ServerRequest(SERV_REQ_LOGIN, 0, NULL);
+        }
+        SetTimeoutRTCP(piLinkConf->pControl);
       }
 
-      if(LoginInterval == 0) {
+      if (ChatPort != 0) {
+        if ((Err = CreateServerClient(piLinkConf, ChatPort, TRUE, &pClient)) !=
+            0) {
+          break;
+        }
+        ChatClient = pClient;
+        pClient->State = CmdLine_Handler;
+        ChatCC.pCS = piLinkConf;
+        ChatCC.bCmdLine = TRUE;
+        ChatCC.bSysop = TRUE;
+        ChatCC.bAdmin = TRUE;
+        ChatCC.Callsign = TBDCHAT;
+        ChatCC.CallPlus = ChatCC.Callsign;
+        ChatCC.Proto = PROTO_ILINK;
+      }
+    }
+
+    if (LoginInterval == 0) {
       // We'll never login, set a phoney NodeID so SF will run
-         OurNodeID = crc32(0,(Bytef *) ConferenceCall,strlen(ConferenceCall));
-         NextLoginTime = 0;
-         NextStationListTime = 0;
-      }
+      OurNodeID = crc32(0, (Bytef *)ConferenceCall, strlen(ConferenceCall));
+      NextLoginTime = 0;
+      NextStationListTime = 0;
+    }
 
-   } while(FALSE);
+  } while (FALSE);
 
-   return Err;
+  return Err;
 }
-
 
 // Init Speakfreely conference
-int SFConfInit()
-{
-   ConfServer *pCS;
-   int Err = 0;   // assume the best
+int SFConfInit() {
+  ConfServer *pCS;
+  int Err = 0; // assume the best
 
-   if(LinkConferences) {
-      Err = CreateConference(SF_Port,piLinkConf,&pCS);
-   }
-   else {
-      Err = CreateConference(SF_Port,NULL,&pCS);
-   }
+  if (LinkConferences) {
+    Err = CreateConference(SF_Port, piLinkConf, &pCS);
+  } else {
+    Err = CreateConference(SF_Port, NULL, &pCS);
+  }
 
-   if(Err == 0) {
-      pCS->AudioPort = SF_ReplyPort;
-      pCS->bSFConf = TRUE;
+  if (Err == 0) {
+    pCS->AudioPort = SF_ReplyPort;
+    pCS->bSFConf = TRUE;
 
-      pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
+    pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
 
-      pCS->pAudio->State = RTP_Handler;
-      pCS->pControl->State = RTCP_Handler;
-   }
-   return Err;
+    pCS->pAudio->State = RTP_Handler;
+    pCS->pControl->State = RTCP_Handler;
+  }
+  return Err;
 }
 
-void SendSDES2All(ClientInfo *p,ConfServer *pCS)
-{
-   ConfClient *pCC = NULL;
-   struct avl_traverser avl_trans;
-   char *pSDES;
-   int Len;
-   int i;
-   int bNeedPass[NUM_PROTOCOLS+1];
-   int Protocol = PROTO_SF;
-   int bTxtExtension = FALSE;
+void SendSDES2All(ClientInfo *p, ConfServer *pCS) {
+  ConfClient *pCC = NULL;
+  struct avl_traverser avl_trans;
+  char *pSDES;
+  int Len;
+  int i;
+  int bNeedPass[NUM_PROTOCOLS + 1];
+  int Protocol = PROTO_SF;
+  int bTxtExtension = FALSE;
 
-   memset(bNeedPass,0,sizeof(bNeedPass));
+  memset(bNeedPass, 0, sizeof(bNeedPass));
 
-   if(pCS->biLinkConf) {
-      bNeedPass[PROTO_ILINK] = TRUE;
-   }
-   else if(pCS->bSFConf) {
-      bNeedPass[PROTO_SF] = TRUE;
-   }
-   else if(pCS->bRTPConf) {
-      bNeedPass[PROTO_RTP] = TRUE;
-   }
+  if (pCS->biLinkConf) {
+    bNeedPass[PROTO_ILINK] = TRUE;
+  } else if (pCS->bSFConf) {
+    bNeedPass[PROTO_SF] = TRUE;
+  } else if (pCS->bRTPConf) {
+    bNeedPass[PROTO_RTP] = TRUE;
+  }
 
-// Loop thru clients N+1 times, once for each protocol
-// plus once for old versions of thebridge that used the private "txt" 
-// extension to pass the callsign of the station talking
+  // Loop thru clients N+1 times, once for each protocol
+  // plus once for old versions of thebridge that used the private "txt"
+  // extension to pass the callsign of the station talking
 
-   for(i = 0; i < NUM_PROTOCOLS+1; i++, Protocol++) {
-      if(!bNeedPass[i]) {
+  for (i = 0; i < NUM_PROTOCOLS + 1; i++, Protocol++) {
+    if (!bNeedPass[i]) {
       // Don't need this pass, skip it
-         continue;
-      }
-      
-      if(i == NUM_PROTOCOLS) {
-      // Ilink protocols /w private "txt" extension used by 
+      continue;
+    }
+
+    if (i == NUM_PROTOCOLS) {
+      // Ilink protocols /w private "txt" extension used by
       // old versions of thebridge
-         Protocol = PROTO_ILINK;
-         bTxtExtension = TRUE;
-      }
+      Protocol = PROTO_ILINK;
+      bTxtExtension = TRUE;
+    }
 
-      GenSDES(Protocol+1,bTxtExtension);
+    GenSDES(Protocol + 1, bTxtExtension);
 
-      pSDES = gProtoData[Protocol].OurSDES;
-      Len = gProtoData[Protocol].SDESLen;
+    pSDES = gProtoData[Protocol].OurSDES;
+    Len = gProtoData[Protocol].SDESLen;
 
-      if(Len > 0) {
-         pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-      }
+    if (Len > 0) {
+      pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+    }
 
-      while(pCC != NULL) {
-         if(!pCC->bKicked && pCC->Proto == Protocol) {
-            if(Protocol == PROTO_ILINK) {
-               if(i == PROTO_ILINK) {
-                  if(pCC->bTxtExtension) {
-                  // Client needs txt extension, send in later pass
-                     bNeedPass[NUM_PROTOCOLS] = TRUE;
-                  }
-                  else {
-                  // send SDES w/o txt extension
-                     Send2(pCC,pSDES,Len,TRUE);
-                  }
-               }
-               else if(pCC->bTxtExtension) {
-               // send SDES w txt extension
-                  Send2(pCC,pSDES,Len,TRUE);
-               }
+    while (pCC != NULL) {
+      if (!pCC->bKicked && pCC->Proto == Protocol) {
+        if (Protocol == PROTO_ILINK) {
+          if (i == PROTO_ILINK) {
+            if (pCC->bTxtExtension) {
+              // Client needs txt extension, send in later pass
+              bNeedPass[NUM_PROTOCOLS] = TRUE;
+            } else {
+              // send SDES w/o txt extension
+              Send2(pCC, pSDES, Len, TRUE);
             }
-            else {
-            // send Speak freely / RTP SDES 
-               Send2(pCC,pSDES,Len,TRUE);
-            }
-         }
-         pCC = (ConfClient *) avl_t_next(&avl_trans);
+          } else if (pCC->bTxtExtension) {
+            // send SDES w txt extension
+            Send2(pCC, pSDES, Len, TRUE);
+          }
+        } else {
+          // send Speak freely / RTP SDES
+          Send2(pCC, pSDES, Len, TRUE);
+        }
       }
-   }
-   pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
+      pCC = (ConfClient *)avl_t_next(&avl_trans);
+    }
+  }
+  pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
 }
 
-void DisconnectCC(ClientInfo *p,ConfClient *pCC,char *Reason)
-{
-   p->Count = GenBye(pCC,p->Buf,Reason);
-   pCC->bKicked = TRUE;
-   pCC->bSWL = TRUE;
-   pCC->bPermanent = FALSE;
-   pCC->bInConf = FALSE;
-   pCC->bDisconnected = TRUE;
-   if(pCC->bConnected) {
-      pCC->bConnected = FALSE;
-      ConferenceClients--;
-   }
-   SendBuf2(p,pCC,TRUE);
+void DisconnectCC(ClientInfo *p, ConfClient *pCC, char *Reason) {
+  p->Count = GenBye(pCC, p->Buf, Reason);
+  pCC->bKicked = TRUE;
+  pCC->bSWL = TRUE;
+  pCC->bPermanent = FALSE;
+  pCC->bInConf = FALSE;
+  pCC->bDisconnected = TRUE;
+  if (pCC->bConnected) {
+    pCC->bConnected = FALSE;
+    ConferenceClients--;
+  }
+  SendBuf2(p, pCC, TRUE);
 }
 
-void FwdTextCmdLine(ClientInfo *p,char *Buf,ConfClient *pCC)
-{
-   char *cp;
-   char TempBuf[CONF_BUF_SIZE];
-   int Count;
+void FwdTextCmdLine(ClientInfo *p, char *Buf, ConfClient *pCC) {
+  char *cp;
+  char TempBuf[CONF_BUF_SIZE];
+  int Count;
 
-   if(pCC->HisAdr.PORT != 0) {
-   // Strip Text header from message and add TBD_CHAT_TEXT result code 
-   // to the beginning of the packet
-   
-      Count = snprintf(TempBuf,sizeof(TempBuf),"%d\r%s",TBD_CHAT_TEXT,
-                       &Buf[sizeof(NDATA)]);
-   
-      if(Count == -1 || Count >= sizeof(TempBuf)) {
-      // Pre-C99 style snprintf returns -1 on buffer overflow.  
+  if (pCC->HisAdr.PORT != 0) {
+    // Strip Text header from message and add TBD_CHAT_TEXT result code
+    // to the beginning of the packet
+
+    Count = snprintf(TempBuf, sizeof(TempBuf), "%d\r%s", TBD_CHAT_TEXT,
+                     &Buf[sizeof(NDATA)]);
+
+    if (Count == -1 || Count >= sizeof(TempBuf)) {
+      // Pre-C99 style snprintf returns -1 on buffer overflow.
       // C99 style snprintf returns the number of characters that would
       // have been written on buffer overflow.
       // In either case the output was truncated and p->Count is bogus.
-   
-         Count = sizeof(TempBuf) - 1;
-         Buf[Count] = 0;
-      }
-   
-      // convert \r end of line convention into *nix standard \n
-   
-      cp = TempBuf;
-      while((cp = strchr(cp,'\r')) != NULL) {
-         *cp = '\n';
-      }
-   
-      sendto(p->Socket,TempBuf,Count+1,0,&pCC->HisAdr.s,sizeof(IPAdrUnion));
-   }
+
+      Count = sizeof(TempBuf) - 1;
+      Buf[Count] = 0;
+    }
+
+    // convert \r end of line convention into *nix standard \n
+
+    cp = TempBuf;
+    while ((cp = strchr(cp, '\r')) != NULL) {
+      *cp = '\n';
+    }
+
+    sendto(p->Socket, TempBuf, Count + 1, 0, &pCC->HisAdr.s,
+           sizeof(IPAdrUnion));
+  }
 }
 
-void RTP_Data(ClientInfo *p,ConfServer *pCS,ConfClient *pLookup)
-{
-   ConfClient *pCC = NULL;
-   ConfClient *pSource = NULL;
-   ConfClient *pNextCC = NULL;
-   struct avl_traverser avl_trans;
-   char *cp;
-   char *cp1;
-   rtp_hdr_t *pRTP = (rtp_hdr_t *) p->Buf;
-   int bConfSrc = FALSE;
-   u_int32 OrigSSRC = 0;
-   int bNewTalker = FALSE;
-   int AudioDeltaT;
-   int bFwdPacket = FALSE;
-   int bFwdFullDpxOnly = FALSE;
-   int i,j;
-   int Count;
-   char *Buf;
-   PacketType Type;
-   int bHaveiLinkData = FALSE;
-   Protocol InputProto;
-   int RxLen = p->Count;
-   int bUserChat  = TRUE;
-   int bSysopChat = TRUE;
-   u_int8 CompressionType;
-   ConfServer *pMasterCS = pCS->pMasterCS;
+void RTP_Data(ClientInfo *p, ConfServer *pCS, ConfClient *pLookup) {
+  ConfClient *pCC = NULL;
+  ConfClient *pSource = NULL;
+  ConfClient *pNextCC = NULL;
+  struct avl_traverser avl_trans;
+  char *cp;
+  char *cp1;
+  rtp_hdr_t *pRTP = (rtp_hdr_t *)p->Buf;
+  int bConfSrc = FALSE;
+  u_int32 OrigSSRC = 0;
+  int bNewTalker = FALSE;
+  int AudioDeltaT;
+  int bFwdPacket = FALSE;
+  int bFwdFullDpxOnly = FALSE;
+  int i, j;
+  int Count;
+  char *Buf;
+  PacketType Type;
+  int bHaveiLinkData = FALSE;
+  Protocol InputProto;
+  int RxLen = p->Count;
+  int bUserChat = TRUE;
+  int bSysopChat = TRUE;
+  u_int8 CompressionType;
+  ConfServer *pMasterCS = pCS->pMasterCS;
 
-   if(pLookup->bFilePlayer || pLookup->bCmdLine) {
-      pSource = pCC = pLookup;
-   }
-   else if((pSource = pCC = avl_find(pCS->ConfTree,pLookup)) == NULL) {
-      LOG_NORM(("RTP_Data: Failed to find client %s\n",
-                inet_ntoa(pLookup->HisAdr.i.sin_addr)));
-   }
-   
-   if(pCC != NULL) {
-      pCC->RxBytes += RxLen + HEADER_OVERHEAD;
-      InputProto = pCC->Proto;
-      CompressionType = pCC->CompressionType;
-      
-      for(i = 0; i < NUM_PROTOCOLS; i++) {
-         gProtoData[i].bDataValid = FALSE;
-         for(j = 0; j < MAX_CONV_PACKETS; j++) {
-            gProtoData[i].DataLen[j] = 0;
-         }
+  if (pLookup->bFilePlayer || pLookup->bCmdLine) {
+    pSource = pCC = pLookup;
+  } else if ((pSource = pCC = avl_find(pCS->ConfTree, pLookup)) == NULL) {
+    LOG_NORM(("RTP_Data: Failed to find client %s\n",
+              inet_ntoa(pLookup->HisAdr.i.sin_addr)));
+  }
+
+  if (pCC != NULL) {
+    pCC->RxBytes += RxLen + HEADER_OVERHEAD;
+    InputProto = pCC->Proto;
+    CompressionType = pCC->CompressionType;
+
+    for (i = 0; i < NUM_PROTOCOLS; i++) {
+      gProtoData[i].bDataValid = FALSE;
+      for (j = 0; j < MAX_CONV_PACKETS; j++) {
+        gProtoData[i].DataLen[j] = 0;
       }
+    }
 
-      if(InputProto == PROTO_ILINK) {
-         bHaveiLinkData = TRUE;
-      }
+    if (InputProto == PROTO_ILINK) {
+      bHaveiLinkData = TRUE;
+    }
 
-      gProtoData[InputProto].Data[0] = p->Buf;
-      gProtoData[InputProto].DataLen[0] = RxLen;
-      gProtoData[InputProto].bDataValid = TRUE;
-      gProtoData[InputProto].Type = Type = GetPacketType(p,pCC);
-      bConfSrc = pCC->bConf;
+    gProtoData[InputProto].Data[0] = p->Buf;
+    gProtoData[InputProto].DataLen[0] = RxLen;
+    gProtoData[InputProto].bDataValid = TRUE;
+    gProtoData[InputProto].Type = Type = GetPacketType(p, pCC);
+    bConfSrc = pCC->bConf;
 
-      if(pCC->bSWL || Type == PKT_TYPE_IGNORE) {
-      // Ignore packet, client is an SWL or the packet is an unknown or 
+    if (pCC->bSWL || Type == PKT_TYPE_IGNORE) {
+      // Ignore packet, client is an SWL or the packet is an unknown or
       // unhandled type
-      }
-      else if(pCC->State != NULL) {
-         pCC->State(p,pCC,EVENT_RTP_RX);
-      }
-      else if(Type == PKT_TYPE_CMD && InputProto == PROTO_ILINK) {
+    } else if (pCC->State != NULL) {
+      pCC->State(p, pCC, EVENT_RTP_RX);
+    } else if (Type == PKT_TYPE_CMD && InputProto == PROTO_ILINK) {
       // Command
-         if(STRCMP(p->Buf,"//ver.") == 0) {
-         // Version request
-            p->Count = 0;  // init for BufPrintf
-            BufPrintf(p,"%c" NDATA"%s ",ILINK_DATA_PACKET,ConferenceCall);
-            CmdVersion(p,pCC,NULL);
-            p->Count++;    // include terminating null
-            Send2(pCC,p->Buf,p->Count,FALSE);
-         }
-         else if(ConfCmdEnable) {
-            cp = &p->Buf[strlen(NDATA)+1];   // Point to first character of data
-            if((cp1 = strchr(cp,'>')) != NULL) {
-               if((cp = strchr(&cp1[2],'\r')) != NULL) {
-                  *cp = 0;
-               }
-               ConferenceCmd(p,pCC,&cp1[2]);
-            // Don't forward commands to other conference users
-               bFwdPacket = FALSE;
-            }
-         }
+      if (STRCMP(p->Buf, "//ver.") == 0) {
+        // Version request
+        p->Count = 0; // init for BufPrintf
+        BufPrintf(p, "%c" NDATA "%s ", ILINK_DATA_PACKET, ConferenceCall);
+        CmdVersion(p, pCC, NULL);
+        p->Count++; // include terminating null
+        Send2(pCC, p->Buf, p->Count, FALSE);
+      } else if (ConfCmdEnable) {
+        cp = &p->Buf[strlen(NDATA) + 1]; // Point to first character of data
+        if ((cp1 = strchr(cp, '>')) != NULL) {
+          if ((cp = strchr(&cp1[2], '\r')) != NULL) {
+            *cp = 0;
+          }
+          ConferenceCmd(p, pCC, &cp1[2]);
+          // Don't forward commands to other conference users
+          bFwdPacket = FALSE;
+        }
       }
-      else if(Type == PKT_TYPE_DATA) {
-         if(!bHaveiLinkData) {
-            ConvertProtocol(gProtoData,InputProto,PROTO_ILINK,bNewTalker);
-            if(gProtoData[PROTO_ILINK].DataLen[0] > 0) {
-               bHaveiLinkData = TRUE;
-            }
-         }
-
-         if(bHaveiLinkData && !pCC->bMuteChat) {
-            bFwdPacket = TRUE;
-            if(pCC->bSysop) {
-               char *Temp = FirstChatChar(gProtoData[PROTO_ILINK].Data[0]);
-               if(Temp != NULL) {
-                  if(*Temp == ';') {
-                  // First character is a ';' for forward this message to
-                  // Admins and sysop's only
-                     bUserChat = FALSE;
-                  }
-                  else if(*Temp == ',') {
-                  // First character is a ',' for forward this message to
-                  // Admins only
-                     bUserChat  = FALSE;
-                     bSysopChat = FALSE;
-                  }
-               }
-            }
-
-            Buf = gProtoData[PROTO_ILINK].Data[0];
-            SendChatEvent(pCC->bCmdLine ? "sent_chat" : "chat",Buf);
-            if(!pCC->bCmdLine) {
-                if(bCmdLineChatMode) {
-                   FwdTextCmdLine(p,Buf,&CmdLineCC);
-                }
-                if(ChatPort != 0) {
-                   FwdTextCmdLine(p,Buf,&ChatCC);
-                }
-            }
-         }
+    } else if (Type == PKT_TYPE_DATA) {
+      if (!bHaveiLinkData) {
+        ConvertProtocol(gProtoData, InputProto, PROTO_ILINK, bNewTalker);
+        if (gProtoData[PROTO_ILINK].DataLen[0] > 0) {
+          bHaveiLinkData = TRUE;
+        }
       }
-      else if(Type == PKT_TYPE_AUDIO && !pCC->bMuted && !FromUs(p,pCC)) {
+
+      if (bHaveiLinkData && !pCC->bMuteChat) {
+        bFwdPacket = TRUE;
+        if (pCC->bSysop) {
+          char *Temp = FirstChatChar(gProtoData[PROTO_ILINK].Data[0]);
+          if (Temp != NULL) {
+            if (*Temp == ';') {
+              // First character is a ';' for forward this message to
+              // Admins and sysop's only
+              bUserChat = FALSE;
+            } else if (*Temp == ',') {
+              // First character is a ',' for forward this message to
+              // Admins only
+              bUserChat = FALSE;
+              bSysopChat = FALSE;
+            }
+          }
+        }
+
+        Buf = gProtoData[PROTO_ILINK].Data[0];
+        SendChatEvent(pCC->bCmdLine ? "sent_chat" : "chat", Buf);
+        if (!pCC->bCmdLine) {
+          if (bCmdLineChatMode) {
+            FwdTextCmdLine(p, Buf, &CmdLineCC);
+          }
+          if (ChatPort != 0) {
+            FwdTextCmdLine(p, Buf, &ChatCC);
+          }
+        }
+      }
+    } else if (Type == PKT_TYPE_AUDIO && !pCC->bMuted && !FromUs(p, pCC)) {
       // Audio packet, not originally from us and client is not muted
-         pCC->LastAudioIn = TimeNow;
-         if(!pCC->bTalking) {
-            pCC->FirstAudioIn = TimeNow;
-            pCC->bTalking = TRUE;
-         }
+      pCC->LastAudioIn = TimeNow;
+      if (!pCC->bTalking) {
+        pCC->FirstAudioIn = TimeNow;
+        pCC->bTalking = TRUE;
+      }
 
-         if(ClientTalking == NULL && !pCC->bTimedOut && pCC->bInConf) {
-         // A new station is trying to talk
+      if (ClientTalking == NULL && !pCC->bTimedOut && pCC->bInConf) {
+        // A new station is trying to talk
 
-            if(pCC->bSysop || pCC == LastTalker) {
+        if (pCC->bSysop || pCC == LastTalker) {
+          // Ok to talk now.
+          bNewTalker = TRUE;
+        } else {
+          // First apply the minimum pause time
+          AudioDeltaT = TimeLapse(pCS->pLastAudioIn);
+          if (PauseTime == 0 || AudioDeltaT >= PauseTime) {
             // Ok to talk now.
-               bNewTalker = TRUE;
-            }
-            else {
-            // First apply the minimum pause time
-               AudioDeltaT = TimeLapse(pCS->pLastAudioIn);
-               if(PauseTime == 0 || AudioDeltaT >= PauseTime) {
-               // Ok to talk now.
-                  bNewTalker = TRUE;
-               }
-               else if(InputProto == PROTO_ILINK && !pCC->bPauseWarningSent &&
-                       !pCC->bConf)
-               {
-                  pCC->bPauseWarningSent = TRUE;
-                  DPRINTF(("RTP_Rx(): Sending pause warning\n"));
-                  p->Count = 0;
-                  BufPrintf(p,"%c" NDATA "%s>%s please pause for at least %d.%d"
-                            " seconds between transmissions!\r",
-                            ILINK_DATA_PACKET,ConferenceCall,pCC->Callsign,
-                            PauseTime/1000,PauseTime % 1000);
-                  p->Count++;    // include terminating null
-                  SendBuf2(p,pCC,FALSE);
-               }
+            bNewTalker = TRUE;
+          } else if (InputProto == PROTO_ILINK && !pCC->bPauseWarningSent &&
+                     !pCC->bConf) {
+            pCC->bPauseWarningSent = TRUE;
+            DPRINTF(("RTP_Rx(): Sending pause warning\n"));
+            p->Count = 0;
+            BufPrintf(p,
+                      "%c" NDATA "%s>%s please pause for at least %d.%d"
+                      " seconds between transmissions!\r",
+                      ILINK_DATA_PACKET, ConferenceCall, pCC->Callsign,
+                      PauseTime / 1000, PauseTime % 1000);
+            p->Count++; // include terminating null
+            SendBuf2(p, pCC, FALSE);
+          }
 
-            // Now apply the belch filter
-               if(BelchTime > 0 && bNewTalker && pCC->bBelcher) {
-               // A potential belcher, see if he's talked long
-               // enough that it's not a belch.
-                  AudioDeltaT = TimeLapse(&pCC->FirstAudioIn);
-                  if(AudioDeltaT < BelchTime) {
-                  // Not yet your grossness
-                     bNewTalker = FALSE;
-                  }
-               }
+          // Now apply the belch filter
+          if (BelchTime > 0 && bNewTalker && pCC->bBelcher) {
+            // A potential belcher, see if he's talked long
+            // enough that it's not a belch.
+            AudioDeltaT = TimeLapse(&pCC->FirstAudioIn);
+            if (AudioDeltaT < BelchTime) {
+              // Not yet your grossness
+              bNewTalker = FALSE;
             }
+          }
+        }
 
-            if(bNewTalker) {
-            // A new station is talking
-               CalcBW(pCS,TRUE);
-               SetTimeout(pCS->pAudio,ConfAudioTimeout);
-               LastTalker = ClientTalking = pCC;
-               pCS->bSendStationList = TRUE;
-               pCC->bLurking = FALSE;
+        if (bNewTalker) {
+          // A new station is talking
+          CalcBW(pCS, TRUE);
+          SetTimeout(pCS->pAudio, ConfAudioTimeout);
+          LastTalker = ClientTalking = pCC;
+          pCS->bSendStationList = TRUE;
+          pCC->bLurking = FALSE;
 
-            // Move him to the top of the station list
-               RemoveFromStationList(pCC);
-               pCC->Link = StationList;
-               StationList = pCC;
+          // Move him to the top of the station list
+          RemoveFromStationList(pCC);
+          pCC->Link = StationList;
+          StationList = pCC;
 
-               if(pCS->bLinkedConfs) {
-               // We have linked conferences listening, send them an
-               // SDES before the audio packet so they can tell who's talking
-                  SendSDES2All(p,pCS);
-               }
-            }
-         }
-
-         if(pCC == ClientTalking || 
-            (FullDuplex && (pCC->bFullDuplex || pCC->Proto == PROTO_RTP) && 
-             pCC->bInConf)) 
-         {
-            *pCS->pLastAudioIn = TimeNow;
-            bFwdPacket = TRUE;
-            if(pCC != ClientTalking) {
-            // Not the station with the talk token, only forward his packets
-            // to other full duplex stations
-               bFwdFullDpxOnly = TRUE;
-            }
-            if(BlabOffTimer != 0) {
-               if((TimeNow.tv_sec - pCC->FirstAudioIn.tv_sec) > BlabOffTimer) {
-               // long winded so and so !
-                  bFwdPacket = FALSE;
-                  if(!pCC->bTimedOut) {
-                     p->Count = 0;  // init for BufPrintf
-                     LOG_WARN(("%s timed out.\n",pCC->Callsign));
-                     BufPrintf(p,"%c" NDATA "%s>%s you have timed out!\r"
-                               "The timeout timer on this conference is set to "
-                               "%d seconds.\r",
-                               ILINK_DATA_PACKET,ConferenceCall,pCC->Callsign,
-                               BlabOffTimer);
-                     p->Count++;    // include terminating null
-                     SendBuf2(p,pCC,FALSE);
-                     pCC->bTimedOut = TRUE;
-                     ClientTalking = NULL;   // let someone else talk!
-                     pCS->bSendStationList = TRUE;
-                  }
-               }
-            }
-         }
-         else if(ClientTalking != NULL && !pCC->bDoublingWarningSent &&
-                 InputProto == PROTO_ILINK && !pCC->bConf && 
-                 !pCC->bFilePlayer && !pCC->bFullDuplex)
-         {  // Station is doubling !
-            pCC->bDoublingWarningSent = TRUE;
-            p->Count = 0;  // init for BufPrintf
-            BufPrintf(p,"%c" NDATA "%s>%s you are DOUBLING with %s!\r",
-                      ILINK_DATA_PACKET,ConferenceCall,pCC->Callsign,
-                      ClientTalking->Callsign);
-            p->Count++;    // include terminating null
-            SendBuf2(p,pCC,FALSE);
-         }
+          if (pCS->bLinkedConfs) {
+            // We have linked conferences listening, send them an
+            // SDES before the audio packet so they can tell who's talking
+            SendSDES2All(p, pCS);
+          }
+        }
       }
 
-      if(bFwdPacket) {
-         pNextCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
+      if (pCC == ClientTalking ||
+          (FullDuplex && (pCC->bFullDuplex || pCC->Proto == PROTO_RTP) &&
+           pCC->bInConf)) {
+        *pCS->pLastAudioIn = TimeNow;
+        bFwdPacket = TRUE;
+        if (pCC != ClientTalking) {
+          // Not the station with the talk token, only forward his packets
+          // to other full duplex stations
+          bFwdFullDpxOnly = TRUE;
+        }
+        if (BlabOffTimer != 0) {
+          if ((TimeNow.tv_sec - pCC->FirstAudioIn.tv_sec) > BlabOffTimer) {
+            // long winded so and so !
+            bFwdPacket = FALSE;
+            if (!pCC->bTimedOut) {
+              p->Count = 0; // init for BufPrintf
+              LOG_WARN(("%s timed out.\n", pCC->Callsign));
+              BufPrintf(p,
+                        "%c" NDATA "%s>%s you have timed out!\r"
+                        "The timeout timer on this conference is set to "
+                        "%d seconds.\r",
+                        ILINK_DATA_PACKET, ConferenceCall, pCC->Callsign,
+                        BlabOffTimer);
+              p->Count++; // include terminating null
+              SendBuf2(p, pCC, FALSE);
+              pCC->bTimedOut = TRUE;
+              ClientTalking = NULL; // let someone else talk!
+              pCS->bSendStationList = TRUE;
+            }
+          }
+        }
+      } else if (ClientTalking != NULL && !pCC->bDoublingWarningSent &&
+                 InputProto == PROTO_ILINK && !pCC->bConf &&
+                 !pCC->bFilePlayer &&
+                 !pCC->bFullDuplex) { // Station is doubling !
+        pCC->bDoublingWarningSent = TRUE;
+        p->Count = 0; // init for BufPrintf
+        BufPrintf(p, "%c" NDATA "%s>%s you are DOUBLING with %s!\r",
+                  ILINK_DATA_PACKET, ConferenceCall, pCC->Callsign,
+                  ClientTalking->Callsign);
+        p->Count++; // include terminating null
+        SendBuf2(p, pCC, FALSE);
       }
+    }
 
-      if(pNextCC != NULL && pMasterCS->bRecording && !bHaveiLinkData &&
-         CompressionType == RTP_PT_GSM) 
-      {
-         ConvertProtocol(gProtoData,InputProto,PROTO_ILINK,bNewTalker);
-         if(gProtoData[PROTO_ILINK].DataLen[0] > 0) {
-            bHaveiLinkData = TRUE;
-         }
+    if (bFwdPacket) {
+      pNextCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+    }
+
+    if (pNextCC != NULL && pMasterCS->bRecording && !bHaveiLinkData &&
+        CompressionType == RTP_PT_GSM) {
+      ConvertProtocol(gProtoData, InputProto, PROTO_ILINK, bNewTalker);
+      if (gProtoData[PROTO_ILINK].DataLen[0] > 0) {
+        bHaveiLinkData = TRUE;
       }
-      
-      if(pNextCC != NULL && pMasterCS->bRecording && bNewTalker && 
-         bHaveiLinkData) 
-      {
-         FilePacketHdr PktHdr;
+    }
+
+    if (pNextCC != NULL && pMasterCS->bRecording && bNewTalker &&
+        bHaveiLinkData) {
+      FilePacketHdr PktHdr;
 
       // timestamp this entry, we have a new talker
-         PktHdr.Flags = htonl(FILE_FLAG_TIME_STAMP);
-         PktHdr.Len = htonl(TimeNow.tv_sec);
-         
-         if(fwrite(&PktHdr,sizeof(PktHdr),1,pMasterCS->fp) != 1) {
-         // Write error
-            LOG_ERROR(("RTP_Rx(): fwrite failed, %s",Err2String(errno)));
-            fclose(pMasterCS->fp);
-            pMasterCS->fp = NULL;
-            pMasterCS->bRecording = FALSE;
-         }
+      PktHdr.Flags = htonl(FILE_FLAG_TIME_STAMP);
+      PktHdr.Len = htonl(TimeNow.tv_sec);
+
+      if (fwrite(&PktHdr, sizeof(PktHdr), 1, pMasterCS->fp) != 1) {
+        // Write error
+        LOG_ERROR(("RTP_Rx(): fwrite failed, %s", Err2String(errno)));
+        fclose(pMasterCS->fp);
+        pMasterCS->fp = NULL;
+        pMasterCS->bRecording = FALSE;
+      }
+    }
+
+    if (bFwdPacket && pMasterCS->bRecording && bHaveiLinkData) {
+      FilePacketHdr PktHdr;
+
+      for (i = 0; i < MAX_CONV_PACKETS; i++) {
+        if ((Count = gProtoData[PROTO_ILINK].DataLen[i]) == 0) {
+          break;
+        }
+        Buf = gProtoData[PROTO_ILINK].Data[i];
+        Count = gProtoData[PROTO_ILINK].DataLen[i];
+
+        PktHdr.Len = htonl(Count);
+        PktHdr.Flags = 0;
+        if (Type == PKT_TYPE_DATA) {
+          PktHdr.Flags |= FILE_FLAG_DATA_PKT;
+          if (ClientTalking == NULL) {
+            PktHdr.Flags |= FILE_FLAG_RATE_LIMIT;
+          }
+        } else {
+          PktHdr.Flags |= FILE_FLAG_RATE_LIMIT;
+        }
+        PktHdr.Flags = htonl(PktHdr.Flags);
+
+        if (fwrite(&PktHdr, sizeof(PktHdr), 1, pMasterCS->fp) != 1 ||
+            fwrite(Buf, Count, 1, pMasterCS->fp) != 1) { // Write error
+          LOG_ERROR(("RTP_Rx(): fwrite failed, %s", Err2String(errno)));
+          fclose(pMasterCS->fp);
+          pMasterCS->fp = NULL;
+          pMasterCS->bRecording = FALSE;
+        }
+      }
+    }
+
+    if (!pCC->bCmdLine) {
+      if (Type == PKT_TYPE_DATA) {
+        if (!ConfTextEnable) {
+          // Text conferencing isn't enabled, don't forward packet
+          pNextCC = NULL;
+        }
+      } else if (!ConfEnable) {
+        // Conferencing isn't enabled, only forward packets from the local
+        // client
+        pNextCC = NULL;
+      }
+    }
+
+    // Forward packet to clients
+    while ((pCC = pNextCC) != NULL) {
+      pNextCC = (ConfClient *)avl_t_next(&avl_trans);
+      if (!pCC->bInConf || pCC->bMonitor || pCC == pSource) {
+        // This guy isn't in the conference at the moment or is
+        // in monitor mode, or is the guy that's talking, ignore him
+        continue;
       }
 
-      if(bFwdPacket && pMasterCS->bRecording && bHaveiLinkData) {
-         FilePacketHdr PktHdr;
-         
-         for(i = 0; i < MAX_CONV_PACKETS; i++) {
-            if((Count = gProtoData[PROTO_ILINK].DataLen[i]) == 0) {
-               break;
-            }
-            Buf = gProtoData[PROTO_ILINK].Data[i];
-            Count = gProtoData[PROTO_ILINK].DataLen[i];
-
-            PktHdr.Len = htonl(Count);
-            PktHdr.Flags = 0;
-            if(Type == PKT_TYPE_DATA) {
-               PktHdr.Flags |= FILE_FLAG_DATA_PKT;
-               if(ClientTalking == NULL) {
-                  PktHdr.Flags |= FILE_FLAG_RATE_LIMIT;
-               }
-            }
-            else {
-               PktHdr.Flags |= FILE_FLAG_RATE_LIMIT;
-            }
-            PktHdr.Flags = htonl(PktHdr.Flags);
-
-            if(fwrite(&PktHdr,sizeof(PktHdr),1,pMasterCS->fp) != 1 ||
-               fwrite(Buf,Count,1,pMasterCS->fp) != 1) 
-            {  // Write error
-               LOG_ERROR(("RTP_Rx(): fwrite failed, %s",Err2String(errno)));
-               fclose(pMasterCS->fp);
-               pMasterCS->fp = NULL;
-               pMasterCS->bRecording = FALSE;
-            }
-         }
+      if (Type == PKT_TYPE_AUDIO) {
+        if (pCC->CompressionType != CompressionType) {
+          // Audio packet of a different compression type than this client,
+          // Don't confuse him.
+          DLOG(DLOG_CODEC_TYPE,
+               ("Not forwarding CType 0x%x, HisCtype: 0x%x to %s.\n",
+                CompressionType, pCC->CompressionType, pCC->Callsign));
+          continue;
+        }
+        if (bFwdFullDpxOnly && !pCC->bFullDuplex) {
+          // only fowarding to full duplex clients and this guy isn't
+          continue;
+        }
       }
 
-      if(!pCC->bCmdLine) {
-         if(Type == PKT_TYPE_DATA) {
-            if(!ConfTextEnable) {
-            // Text conferencing isn't enabled, don't forward packet
-               pNextCC = NULL;
-            }
-         }
-         else if(!ConfEnable) {
-         // Conferencing isn't enabled, only forward packets from the local client
-            pNextCC = NULL;
-         }
+      if (!gProtoData[pCC->Proto].bDataValid) {
+        if (!gProtoData[PROTO_ILINK].bDataValid) {
+          ConvertProtocol(gProtoData, InputProto, PROTO_ILINK, bNewTalker);
+        }
+        ConvertProtocol(gProtoData, PROTO_ILINK, pCC->Proto, bNewTalker);
       }
 
-      // Forward packet to clients
-      while((pCC = pNextCC) != NULL) {
-         pNextCC = (ConfClient *) avl_t_next(&avl_trans);
-         if(!pCC->bInConf || pCC->bMonitor || pCC == pSource) {
-         // This guy isn't in the conference at the moment or is 
-         // in monitor mode, or is the guy that's talking, ignore him
-            continue;
-         }
-         
-         if(Type == PKT_TYPE_AUDIO) {
-            if(pCC->CompressionType != CompressionType) {
-            // Audio packet of a different compression type than this client,
-            // Don't confuse him.
-               DLOG(DLOG_CODEC_TYPE,
-                    ("Not forwarding CType 0x%x, HisCtype: 0x%x to %s.\n",
-                     CompressionType,pCC->CompressionType,pCC->Callsign));
-               continue;
+      for (i = 0; i < MAX_CONV_PACKETS; i++) {
+        if ((Count = gProtoData[pCC->Proto].DataLen[i]) == 0) {
+          break;
+        }
+        Buf = gProtoData[pCC->Proto].Data[i];
+
+        switch (pCC->Proto) {
+        case PROTO_ILINK:
+          if (Type == PKT_TYPE_DATA && !pCC->bNoChat) {
+            // Sending Data packet and the user hasn't muted chat
+            if (bUserChat || (bSysopChat && pCC->bSysop) || pCC->bAdmin) {
+              // forward chat text
+              Send2(pCC, Buf, Count, FALSE);
             }
-            if(bFwdFullDpxOnly && !pCC->bFullDuplex) {
-            // only fowarding to full duplex clients and this guy isn't
-               continue;
+          } else if (Type == PKT_TYPE_AUDIO) {
+            OrigSSRC = pRTP->ssrc;
+            if (pCC->bSendSSRC) {
+              // Sending audio from another conference. If the sssrc is
+              // zero then set our ssrc ID, otherwise just pass the
+              // packet on unmodified.
+              if (pRTP->ssrc == 0) {
+                ZeroSSRC++;
+                pRTP->ssrc = OurNodeID;
+              }
+            } else {
+              // Sending audio to user that may crash if they see a
+              // non-zero ssrc, make sure ssrc is zero
+              pRTP->ssrc = 0;
             }
-         }
 
-         if(!gProtoData[pCC->Proto].bDataValid) {
-            if(!gProtoData[PROTO_ILINK].bDataValid) {
-               ConvertProtocol(gProtoData,InputProto,PROTO_ILINK,bNewTalker);
-            }
-            ConvertProtocol(gProtoData,PROTO_ILINK,pCC->Proto,bNewTalker);
-         }
-         
-         for(i = 0; i < MAX_CONV_PACKETS; i++) {
-            if((Count = gProtoData[pCC->Proto].DataLen[i]) == 0) {
-               break;
-            }
-            Buf = gProtoData[pCC->Proto].Data[i];
+            Send2(pCC, Buf, Count, FALSE);
 
-            switch(pCC->Proto) {
-            case PROTO_ILINK:
-               if(Type == PKT_TYPE_DATA && !pCC->bNoChat) {
-               // Sending Data packet and the user hasn't muted chat
-                  if(bUserChat || (bSysopChat && pCC->bSysop) || pCC->bAdmin) {
-                  // forward chat text
-                     Send2(pCC,Buf,Count,FALSE);
-                  }
-               }
-               else if(Type == PKT_TYPE_AUDIO) {
-                  OrigSSRC = pRTP->ssrc;
-                  if(pCC->bSendSSRC) {
-                  // Sending audio from another conference. If the sssrc is
-                  // zero then set our ssrc ID, otherwise just pass the 
-                  // packet on unmodified.
-                     if(pRTP->ssrc == 0) {
-                        ZeroSSRC++;
-                        pRTP->ssrc = OurNodeID;
-                     }
-                  }
-                  else {
-                  // Sending audio to user that may crash if they see a 
-                  // non-zero ssrc, make sure ssrc is zero
-                     pRTP->ssrc = 0;
-                  }
+            // restore the original ssrc in case it was modified above
+            pRTP->ssrc = OrigSSRC;
+          }
+          break;
 
-                  Send2(pCC,Buf,Count,FALSE);
+        case PROTO_SF:
+          if (Type == PKT_TYPE_AUDIO) {
+            // Audio packet and current user is not talking
+            Send2(pCC, Buf, Count, FALSE);
+          }
+          break;
 
-               // restore the original ssrc in case it was modified above
-                  pRTP->ssrc = OrigSSRC;
-               }
-               break;
-
-            case PROTO_SF:
-               if(Type == PKT_TYPE_AUDIO) {
-               // Audio packet and current user is not talking
-                  Send2(pCC,Buf,Count,FALSE);
-               }
-               break;
-
-            case PROTO_RTP:
-               if(Type == PKT_TYPE_AUDIO) {
-               // Audio packet and current user is not talking
-                  Send2(pCC,Buf,Count,FALSE);
-               }
-               break;
-            }
-         }
+        case PROTO_RTP:
+          if (Type == PKT_TYPE_AUDIO) {
+            // Audio packet and current user is not talking
+            Send2(pCC, Buf, Count, FALSE);
+          }
+          break;
+        }
       }
+    }
 
-      if(Type == PKT_TYPE_AUDIO || Type == PKT_TYPE_OTHER_AUDIO) {
-         EndPoint(p,pSource,EVENT_RTP_RX);
-      }
-   }
+    if (Type == PKT_TYPE_AUDIO || Type == PKT_TYPE_OTHER_AUDIO) {
+      EndPoint(p, pSource, EVENT_RTP_RX);
+    }
+  }
 }
 
-void RTP_Rx(ClientInfo *p,ConfServer *pCS)
-{
-   ConfClient  Lookup;
-   int RxLen;
-   socklen_t Adrlen = sizeof(Lookup.HisAdr);
+void RTP_Rx(ClientInfo *p, ConfServer *pCS) {
+  ConfClient Lookup;
+  int RxLen;
+  socklen_t Adrlen = sizeof(Lookup.HisAdr);
 
-   memset(&Lookup,0,sizeof(Lookup));
+  memset(&Lookup, 0, sizeof(Lookup));
 
-   RxLen = recvfrom(p->Socket,p->Buf,p->BufSize-1,0,&Lookup.HisAdr.s,&Adrlen);
-   Lookup.HisAdr.PORT = pCS->AudioPort;
+  RxLen =
+      recvfrom(p->Socket, p->Buf, p->BufSize - 1, 0, &Lookup.HisAdr.s, &Adrlen);
+  Lookup.HisAdr.PORT = pCS->AudioPort;
 
-   if(RxLen != SOCKET_ERROR) {
-      p->Buf[RxLen] = 0;
-      p->Count = RxLen;
-      pCS->RxBytes += RxLen + HEADER_OVERHEAD;
-      RxBytesAllConf += RxLen + HEADER_OVERHEAD;
-      pCS->RxCount++;
-   }
+  if (RxLen != SOCKET_ERROR) {
+    p->Buf[RxLen] = 0;
+    p->Count = RxLen;
+    pCS->RxBytes += RxLen + HEADER_OVERHEAD;
+    RxBytesAllConf += RxLen + HEADER_OVERHEAD;
+    pCS->RxCount++;
+  }
 
-   if(RxLen == SOCKET_ERROR) {
-      pCS->RxErrs++;
-      DPRINTF(("RTP_Handler(): recvfrom returned %u.\n",ERROR_CODE));
-   }
-   else {
-      RxBytesAllConf += RxLen + HEADER_OVERHEAD;
-      RTP_Data(p,pCS,&Lookup);
-   }
+  if (RxLen == SOCKET_ERROR) {
+    pCS->RxErrs++;
+    DPRINTF(("RTP_Handler(): recvfrom returned %u.\n", ERROR_CODE));
+  } else {
+    RxBytesAllConf += RxLen + HEADER_OVERHEAD;
+    RTP_Data(p, pCS, &Lookup);
+  }
 }
 
-int RTP_Handler(ClientInfo *p)
-{
-   int bClientsWereTalking = ClientTalking != NULL;
-   int bClientsTalking = FALSE;
-   int bConfTalkerFound = FALSE;
-   int bConfFound = FALSE;
-   int AudioDeltaT;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   ConfClient *pCC = avl_t_first(&avl_trans,pCS->ConfTree);
-   
-   GetTimeNow();
+int RTP_Handler(ClientInfo *p) {
+  int bClientsWereTalking = ClientTalking != NULL;
+  int bClientsTalking = FALSE;
+  int bConfTalkerFound = FALSE;
+  int bConfFound = FALSE;
+  int AudioDeltaT;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  ConfClient *pCC = avl_t_first(&avl_trans, pCS->ConfTree);
 
-// Check RTP timeouts
-   while(pCC != NULL) {
-      if(pCC->bConf) {
-         bConfFound = TRUE;
+  GetTimeNow();
+
+  // Check RTP timeouts
+  while (pCC != NULL) {
+    if (pCC->bConf) {
+      bConfFound = TRUE;
+    }
+
+    if (pCC->bTalking) {
+      AudioDeltaT = TimeLapse(&pCC->LastAudioIn);
+
+      if (AudioDeltaT > ConfAudioTimeout) {
+        // This guy has stopped talking
+        EndPoint(p, pCC, EVENT_RTP_TO);
+        if (pCC->bTimedOut) {
+          // remove "Timed out" from users entry in station list
+          pCS->bSendStationList = TRUE;
+          LOG_WARN(("timed out user %s unkeyed.\n", pCC->Callsign));
+        }
+        pCC->bTalking = FALSE;
+        pCC->bTimedOut = FALSE;
+
+        if (pCC->State != NULL) {
+          pCC->State(p, pCC, EVENT_RTP_TO);
+        }
+      } else {
+        // This guy is still talking
+        bClientsTalking = TRUE;
+        if (pCC == ClientTalking && !pCC->bKicked) {
+          bConfTalkerFound = TRUE;
+        }
       }
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-      if(pCC->bTalking) {
-         AudioDeltaT = TimeLapse(&pCC->LastAudioIn);
+  pCS->bLinkedConfs = bConfFound;
 
-         if(AudioDeltaT > ConfAudioTimeout) {
-         // This guy has stopped talking
-            EndPoint(p,pCC,EVENT_RTP_TO);
-            if(pCC->bTimedOut) {
-            // remove "Timed out" from users entry in station list
-               pCS->bSendStationList = TRUE;
-               LOG_WARN(("timed out user %s unkeyed.\n",pCC->Callsign));
-            }
-            pCC->bTalking = FALSE;
-            pCC->bTimedOut = FALSE;
-
-            if(pCC->State != NULL) {
-               pCC->State(p,pCC,EVENT_RTP_TO);
-            }
-         }
-         else {
-         // This guy is still talking
-            bClientsTalking = TRUE;
-            if(pCC == ClientTalking && !pCC->bKicked) {
-               bConfTalkerFound = TRUE;
-            }
-         }
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-
-   pCS->bLinkedConfs = bConfFound;
-
-   if(!bConfTalkerFound && ClientTalking != NULL && 
-      ClientTalking != pCS->pFilePlayer) 
-   {  // The conference is free now
-      CalcBW(pCS,TRUE);
-      ClientTalking = NULL;
-      pCS->bSendStationList = TRUE;
-      if(pCS->bPlayWhenFree) {
+  if (!bConfTalkerFound && ClientTalking != NULL &&
+      ClientTalking != pCS->pFilePlayer) { // The conference is free now
+    CalcBW(pCS, TRUE);
+    ClientTalking = NULL;
+    pCS->bSendStationList = TRUE;
+    if (pCS->bPlayWhenFree) {
       // Waiting to play an file
-         pCS->bPlayWhenFree = FALSE;
-         StartPlayback(pCS->pAudio,pCS->pFilePlayer);
-      }
-   }
+      pCS->bPlayWhenFree = FALSE;
+      StartPlayback(pCS->pAudio, pCS->pFilePlayer);
+    }
+  }
 
-   if(bClientsTalking) {
-   // Set a timeout
-      SetTimeout(p,ConfAudioTimeout);
-   }
-   else {
-   // No one's talking no need for a timeout
-      p->bTimeWait = FALSE;
-   }
-   
-   if(p->bReadReady) {
-      RTP_Rx(p,pCS);
-   }
+  if (bClientsTalking) {
+    // Set a timeout
+    SetTimeout(p, ConfAudioTimeout);
+  } else {
+    // No one's talking no need for a timeout
+    p->bTimeWait = FALSE;
+  }
 
-   if(bClientsWereTalking && ClientTalking == NULL && pCS->bLinkedConfs) {
-   // We have linked conferences listening, send them an
-   // SDES update
-      SendSDES2All(p,pCS);
-   }
+  if (p->bReadReady) {
+    RTP_Rx(p, pCS);
+  }
 
-   if(pCS->bSendStationList) {
-      SendStationList(pCS);
-      pCS->bSendStationList = FALSE;
-   }
+  if (bClientsWereTalking && ClientTalking == NULL && pCS->bLinkedConfs) {
+    // We have linked conferences listening, send them an
+    // SDES update
+    SendSDES2All(p, pCS);
+  }
 
-   return FALSE;
+  if (pCS->bSendStationList) {
+    SendStationList(pCS);
+    pCS->bSendStationList = FALSE;
+  }
+
+  return FALSE;
 }
 
-int AutoLurk(ConfClient *pCC)
-{
-   int bAutoLurk = FALSE;
+int AutoLurk(ConfClient *pCC) {
+  int bAutoLurk = FALSE;
 
-   if(pCC->bRepeater) {
-      if(DefaultAutoLurk & AUTOLURK_REPEATERS) {
-         bAutoLurk = TRUE;
-      }
-   }
-   else if(pCC->bLink) {
-      if(DefaultAutoLurk & AUTOLURK_LINKS) {
-         bAutoLurk = TRUE;
-      }
-   }
-   else if(pCC->bConf) {
-      if(DefaultAutoLurk & AUTOLURK_CONFERENCES) {
-         bAutoLurk = TRUE;
-      }
-   }
-   else if(DefaultAutoLurk & AUTOLURK_HEADSETS) {
+  if (pCC->bRepeater) {
+    if (DefaultAutoLurk & AUTOLURK_REPEATERS) {
       bAutoLurk = TRUE;
-   }
+    }
+  } else if (pCC->bLink) {
+    if (DefaultAutoLurk & AUTOLURK_LINKS) {
+      bAutoLurk = TRUE;
+    }
+  } else if (pCC->bConf) {
+    if (DefaultAutoLurk & AUTOLURK_CONFERENCES) {
+      bAutoLurk = TRUE;
+    }
+  } else if (DefaultAutoLurk & AUTOLURK_HEADSETS) {
+    bAutoLurk = TRUE;
+  }
 
-   return bAutoLurk;
+  return bAutoLurk;
 }
 
-void IncrementClientCount(ConfServer *pCS,ConfClient *pCC)
-{
-   ConferenceClients++;
-   pCS->bSendStationList = TRUE;
+void IncrementClientCount(ConfServer *pCS, ConfClient *pCC) {
+  ConferenceClients++;
+  pCS->bSendStationList = TRUE;
 
-   if(ConferenceClients > PeakClients) {
-      PeakClients = ConferenceClients;
-      PeakClientTime = TimeNow.tv_sec;
-   }
+  if (ConferenceClients > PeakClients) {
+    PeakClients = ConferenceClients;
+    PeakClientTime = TimeNow.tv_sec;
+  }
 }
 
-void AddClient2Conf(ConfServer *pCS,ConfClient *pCC)
-{
-   gProtoData[pCC->Proto].Clients++;
-   pCC->LoginTime = TimeNow.tv_sec;
-   avl_insert(pCS->ConfTree,pCC);
-   pCS->Users++;
-// put our new guy on the top of the station list
-   pCC->Link = StationList;
-   StationList = pCC;
-   if(pCC->bConnected) {
-      IncrementClientCount(pCS,pCC);
-   }
+void AddClient2Conf(ConfServer *pCS, ConfClient *pCC) {
+  gProtoData[pCC->Proto].Clients++;
+  pCC->LoginTime = TimeNow.tv_sec;
+  avl_insert(pCS->ConfTree, pCC);
+  pCS->Users++;
+  // put our new guy on the top of the station list
+  pCC->Link = StationList;
+  StationList = pCC;
+  if (pCC->bConnected) {
+    IncrementClientCount(pCS, pCC);
+  }
 
-   if(pCS->ConfTree->avl_count == 1) {
-   // reset the RTCP timer, the conference was empty before 
-   // so it wasn't running
-      pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
-      SetTimeoutRTCP(pCS->pControl);
+  if (pCS->ConfTree->avl_count == 1) {
+    // reset the RTCP timer, the conference was empty before
+    // so it wasn't running
+    pCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
+    SetTimeoutRTCP(pCS->pControl);
 
-      if(AvrsEnable) {
+    if (AvrsEnable) {
       // Force an AVRS update
-         NextAVRSTime = TimeNow.tv_sec;
-      }
-   }
+      NextAVRSTime = TimeNow.tv_sec;
+    }
+  }
 }
 
+int RTCP_Rx(ClientInfo *p) {
+  int RxLen;
+  int Ret = FALSE;
+  ConfClient Lookup;
+  char *end;
+  ConfClient *pCC;
+  int bNewClient = FALSE;
+  int Authorized = 0;
+  ConfServer *pCS = (ConfServer *)p->p;
+  socklen_t Adrlen = sizeof(Lookup.HisAdr);
+  union {
+    rtcp_common_t *p;
+    rtcp_t *pRTCP;
+    char *cp;
+  } u;
 
-int RTCP_Rx(ClientInfo *p)
-{
-   int RxLen;
-   int Ret = FALSE;
-   ConfClient  Lookup;
-   char *end;
-   ConfClient *pCC;
-   int bNewClient = FALSE;
-   int Authorized = 0;
-   ConfServer *pCS = (ConfServer *) p->p;
-   socklen_t Adrlen = sizeof(Lookup.HisAdr);
-   union {
-      rtcp_common_t *p;
-      rtcp_t *pRTCP;
-      char *cp;
-   } u;
+  union {
+    rtcp_sdes_item_t *p;
+    char *cp;
+  } Item;
+  char RTCP_Ver;
 
-   union {
-      rtcp_sdes_item_t *p;
-      char *cp;
-   } Item;
-   char RTCP_Ver;
-   
-   u.cp = p->Buf;
+  u.cp = p->Buf;
 
-   RxLen = recvfrom(p->Socket,p->Buf,p->BufSize,0,&Lookup.HisAdr.s,&Adrlen);
-   p->Count = RxLen;
-   Lookup.HisAdr.PORT = pCS->AudioPort;
-   
-   if(RxLen == SOCKET_ERROR) {
-      pCS->RxErrs++;
-      DPRINTF(("RTCP_Rx(): recvfrom returned %u.\n",ERROR_CODE));
-      return FALSE;
-   }
-   else {
-      pCS->RxCount++;
-      pCS->RxBytes += RxLen + HEADER_OVERHEAD;
-      RxBytesAllConf += RxLen + HEADER_OVERHEAD;
-   }
+  RxLen = recvfrom(p->Socket, p->Buf, p->BufSize, 0, &Lookup.HisAdr.s, &Adrlen);
+  p->Count = RxLen;
+  Lookup.HisAdr.PORT = pCS->AudioPort;
 
-   if((RTCP_Ver = CheckRTCP(pCS)) == 0) {
-   // Bogus packet, ignore it
-      LOG_WARN(("RTCP_Rx(): ignoring bogus packet from %s.\n",
-                inet_ntoa(Lookup.HisAdr.i.sin_addr)));
-      SaveBadPacket(p,"badrtcp.bin");
-      return FALSE;
-   }
+  if (RxLen == SOCKET_ERROR) {
+    pCS->RxErrs++;
+    DPRINTF(("RTCP_Rx(): recvfrom returned %u.\n", ERROR_CODE));
+    return FALSE;
+  } else {
+    pCS->RxCount++;
+    pCS->RxBytes += RxLen + HEADER_OVERHEAD;
+    RxBytesAllConf += RxLen + HEADER_OVERHEAD;
+  }
 
-   if((pCC = avl_find(pCS->ConfTree,&Lookup)) == NULL) {
-   // New conference client
-      bNewClient = TRUE;
-      pCC = CreateNewConfClient();
-      pCC->pCS = pCS;
-      pCC->Proto = RTCP_Ver - 1;
-      pCC->HisAdr = Lookup.HisAdr;
+  if ((RTCP_Ver = CheckRTCP(pCS)) == 0) {
+    // Bogus packet, ignore it
+    LOG_WARN(("RTCP_Rx(): ignoring bogus packet from %s.\n",
+              inet_ntoa(Lookup.HisAdr.i.sin_addr)));
+    SaveBadPacket(p, "badrtcp.bin");
+    return FALSE;
+  }
 
-      pCC->RxBytes += RxLen + HEADER_OVERHEAD;
-      RxBytesAllConf += RxLen + HEADER_OVERHEAD;
+  if ((pCC = avl_find(pCS->ConfTree, &Lookup)) == NULL) {
+    // New conference client
+    bNewClient = TRUE;
+    pCC = CreateNewConfClient();
+    pCC->pCS = pCS;
+    pCC->Proto = RTCP_Ver - 1;
+    pCC->HisAdr = Lookup.HisAdr;
 
-      if(!GetCall(pCS,pCC,u.pRTCP,RxLen)) {
+    pCC->RxBytes += RxLen + HEADER_OVERHEAD;
+    RxBytesAllConf += RxLen + HEADER_OVERHEAD;
+
+    if (!GetCall(pCS, pCC, u.pRTCP, RxLen)) {
       // Not an SDES (a bye for some we don't have connection with?), ignore it
-         free(pCC);
-         return FALSE;
-      }
-      
-      if(pCC->bConf) {
+      free(pCC);
+      return FALSE;
+    }
+
+    if (pCC->bConf) {
       // Conference
-         if(pCC->bTBD) {
-         // thebridge
-            pCC->bMuted = pCS->bMuteTBD;
-         }
-         else {
-         // EchoLink or other type of conference
-            pCC->bMuted = pCS->bMuteConf;
-         }
+      if (pCC->bTBD) {
+        // thebridge
+        pCC->bMuted = pCS->bMuteTBD;
+      } else {
+        // EchoLink or other type of conference
+        pCC->bMuted = pCS->bMuteConf;
       }
-      else if(pCC->bRepeater || pCC->bLink) {
+    } else if (pCC->bRepeater || pCC->bLink) {
       // RF user
-         pCC->bMuted = pCS->bMuteRF;
-      }
-      else {
+      pCC->bMuted = pCS->bMuteRF;
+    } else {
       // PC User
-         pCC->bMuted = pCS->bMuteUsers;
-      }
+      pCC->bMuted = pCS->bMuteUsers;
+    }
 
-      pCC->bMuteChat = pCS->bMuteChat;
+    pCC->bMuteChat = pCS->bMuteChat;
 
-      if(pCC->Proto == PROTO_ILINK && pCC->Callsign == NULL) {
-         LOG_ERROR(("failed to get callsign from iLink client %s.\n",
-                    inet_ntoa(pCC->HisAdr.i.sin_addr)));
-         SaveBadPacket(p,"nocall.bin");
-      }
+    if (pCC->Proto == PROTO_ILINK && pCC->Callsign == NULL) {
+      LOG_ERROR(("failed to get callsign from iLink client %s.\n",
+                 inet_ntoa(pCC->HisAdr.i.sin_addr)));
+      SaveBadPacket(p, "nocall.bin");
+    }
 
-      pCC->bAutoLurk = AutoLurk(pCC);
+    pCC->bAutoLurk = AutoLurk(pCC);
 
-   // LastAudioIn to the current time (a lie) so new stations don't 
-   // disappear immediately when DefaultAutoLurk is active.
-      pCC->LastAudioIn = TimeNow;
-      
-      if(pCC->Callsign == NULL) {
+    // LastAudioIn to the current time (a lie) so new stations don't
+    // disappear immediately when DefaultAutoLurk is active.
+    pCC->LastAudioIn = TimeNow;
+
+    if (pCC->Callsign == NULL) {
       // Didn't get a callsign, default to the IP address for now
-         pCC->CallPlus = strdup(inet_ntoa(pCC->HisAdr.i.sin_addr));
-         pCC->Callsign = strdup(pCC->CallPlus);
+      pCC->CallPlus = strdup(inet_ntoa(pCC->HisAdr.i.sin_addr));
+      pCC->Callsign = strdup(pCC->CallPlus);
+    }
+
+    Authorized = AuthorizedClient(p, pCC);
+
+    if (bConferenceBusy || ConferenceClients >= MaxConferenceClients ||
+        Authorized != 1) { // Sorry Jack
+      if (Authorized == 1) {
+        LOG_NORM(("%s failed to logon, conference %s.\n", CallLog(pCC),
+                  bConferenceBusy ? "busy" : "full"));
+
+        if (bConferenceBusy) {
+          p->Count = GenBye(pCC, p->Buf, "Sorry the conference is busy");
+        } else {
+          p->Count = GenBye(pCC, p->Buf, "Sorry the conference is full");
+        }
+      } else if (Authorized == 0) {
+        // Sorry Jack, you're not welcome here
+        LOG_NORM(("Disconnecting unauthorized user %s.\n", CallLog(pCC)));
+        p->Count = GenBye(pCC, p->Buf, "Bye Bye");
+      } else {
+        LOG_NORM(("Ignoring unknown user %s (%s).\n", pCC->Callsign,
+                  inet_ntoa(pCC->HisAdr.i.sin_addr)));
       }
 
-      Authorized = AuthorizedClient(p,pCC);
-
-      if(bConferenceBusy || 
-         ConferenceClients >= MaxConferenceClients || 
-         Authorized != 1)
-      {  // Sorry Jack
-         if(Authorized == 1) {
-            LOG_NORM(("%s failed to logon, conference %s.\n",CallLog(pCC),
-                      bConferenceBusy ? "busy" : "full"));
-
-            if(bConferenceBusy) {
-               p->Count = GenBye(pCC,p->Buf,"Sorry the conference is busy");
-            }
-            else {
-               p->Count = GenBye(pCC,p->Buf,"Sorry the conference is full");
-            }
-         }
-         else if(Authorized == 0) {
-         // Sorry Jack, you're not welcome here
-            LOG_NORM(("Disconnecting unauthorized user %s.\n",CallLog(pCC)));
-            p->Count = GenBye(pCC,p->Buf,"Bye Bye");
-         }
-         else {
-            LOG_NORM(("Ignoring unknown user %s (%s).\n",pCC->Callsign,
-                      inet_ntoa(pCC->HisAdr.i.sin_addr)));
-         }
-
-         if(Authorized == 0) {
-            SendBuf2(p,pCC,TRUE);
-         }
-         free(pCC->Callsign);
-         free(pCC->CallPlus);
-         if(pCC->Password != NULL) {
-            free(pCC->Password);
-         }
-         free(pCC);
-         pCC = NULL;
+      if (Authorized == 0) {
+        SendBuf2(p, pCC, TRUE);
       }
-      else {
+      free(pCC->Callsign);
+      free(pCC->CallPlus);
+      if (pCC->Password != NULL) {
+        free(pCC->Password);
+      }
+      free(pCC);
+      pCC = NULL;
+    } else {
       // New user accepted
-         pCC->bConnected = TRUE;
-         AddClient2Conf(pCS,pCC);
-         EndPoint(NULL,pCC,EVENT_INIT);
+      pCC->bConnected = TRUE;
+      AddClient2Conf(pCS, pCC);
+      EndPoint(NULL, pCC, EVENT_INIT);
 
       // NB: *ASSUME* the client is running the same codec as the conference
-      // There's no way to tell if this is actually the case until he sends 
-      // an audio packet.  This may be wrong, but currently thebridge only 
-      // supports welcome messages in GSM format.  If a welcome message is 
-      // played in GSM format for some clients (thelinkbox) they will *SWITCH* 
-      // to GSM when they receive it.  Meaning if you want an ADPCM conference 
+      // There's no way to tell if this is actually the case until he sends
+      // an audio packet.  This may be wrong, but currently thebridge only
+      // supports welcome messages in GSM format.  If a welcome message is
+      // played in GSM format for some clients (thelinkbox) they will *SWITCH*
+      // to GSM when they receive it.  Meaning if you want an ADPCM conference
       // you should *NOT* configure the conference to send a welcome message.
-      // 
+      //
       // A possible solution would be for the client to sent a few empty
       // audio packets on connect to convey the audio type but AFAIK no
       // clients do that.
 
-         pCC->CompressionType = CompressionType;  
-         switch(pCC->Proto) {
-            case PROTO_SF:
-               LOG_NORM(("SF client %s logged in, current users: %d.\n",
-                         CallLog(pCC),ConferenceClients));
-               EventHook("connected speakfreely %s %d",pCC->Callsign,
-                         ConferenceClients);
-               break;
+      pCC->CompressionType = CompressionType;
+      switch (pCC->Proto) {
+      case PROTO_SF:
+        LOG_NORM(("SF client %s logged in, current users: %d.\n", CallLog(pCC),
+                  ConferenceClients));
+        EventHook("connected speakfreely %s %d", pCC->Callsign,
+                  ConferenceClients);
+        break;
 
-            case PROTO_RTP:
-               LOG_NORM(("RTP client %s logged in, current users: %d.\n",
-                         CallLog(pCC),ConferenceClients));
-               EventHook("connected rtp %s %d",pCC->Callsign,ConferenceClients);
-               break;
+      case PROTO_RTP:
+        LOG_NORM(("RTP client %s logged in, current users: %d.\n", CallLog(pCC),
+                  ConferenceClients));
+        EventHook("connected rtp %s %d", pCC->Callsign, ConferenceClients);
+        break;
 
-            case PROTO_ILINK:
-            // EchoLink only supports GSM
-               pCC->CompressionType = RTP_PT_GSM;  
-               LOG_NORM(("%s%s logged in, current users: %d.\n",
-                         CallLog(pCC),pCC->bConf ? " conference" : "",
-                         ConferenceClients));
-               EventHook("connected echolink %s %d",pCC->Callsign,
-                         ConferenceClients);
-               break;
-         }
-
-         if(WelcomeFile != NULL && strstr(WelcomeFile,".wav") == NULL) {
-            if(WelcomeDelay != 0) {
-               if(ClientTalking == NULL) {
-                  pCC->bWelcomePending = TRUE;
-               }
-            }
-            else {
-            // Play the welcome file for him.
-   
-            // NB: Send the station list now, otherwise the new user won't
-            // get a copy because the welcome file will be playing
-               
-               SendStationList(pCS);
-               pCS->bSendStationList = FALSE;
-   
-               OpenAudioFile(pCC,WelcomeFile,MODE_RD_BIN);
-               if(pCC->bFileIOActive) {
-                  StartPlayback(p,pCC);
-               }
-            }
-         }
-         else if(AudioTestConf && FileRecord(NULL,pCC,EVENT_INIT)) {
-            pCC->bInConf = FALSE;
-            pCC->State = FileRecord;
-         }
-      }
-   }
-   else {
-      pCC->RxBytes += RxLen + HEADER_OVERHEAD;
-      RxBytesAllConf += RxLen + HEADER_OVERHEAD;
-   }
-   
-   if(pCC != NULL && pCC->bKicked && pCC->bDisconnected) {
-   // maybe he didn't get the news
-      DisconnectCC(p,pCC,"Goodbye");
-   }
-
-   if(pCC != NULL && !pCC->bKicked) {
-      pCC->LastHeard = TimeNow.tv_sec;
-
-      if(pCC->State != NULL) {
-         pCC->State(p,pCC,EVENT_RTCP_RX);
+      case PROTO_ILINK:
+        // EchoLink only supports GSM
+        pCC->CompressionType = RTP_PT_GSM;
+        LOG_NORM(("%s%s logged in, current users: %d.\n", CallLog(pCC),
+                  pCC->bConf ? " conference" : "", ConferenceClients));
+        EventHook("connected echolink %s %d", pCC->Callsign, ConferenceClients);
+        break;
       }
 
-      Item.p = NULL;
-      end = u.cp + RxLen;
+      if (WelcomeFile != NULL && strstr(WelcomeFile, ".wav") == NULL) {
+        if (WelcomeDelay != 0) {
+          if (ClientTalking == NULL) {
+            pCC->bWelcomePending = TRUE;
+          }
+        } else {
+          // Play the welcome file for him.
 
-      while(u.cp < end) {
-         D3PRINTF(("RTCP_Rx(): processing pt %d.\n",u.p->pt));
-         switch(u.p->pt) {
-            case RTCP_SR:
-               break;
+          // NB: Send the station list now, otherwise the new user won't
+          // get a copy because the welcome file will be playing
 
-            case RTCP_RR:
-               break;
+          SendStationList(pCS);
+          pCS->bSendStationList = FALSE;
 
-            case RTCP_SDES:
-            // Answer with our SDES if he's a new client
-               if(bNewClient) {
-                  SendSDES(pCS,pCC);
-               }
-
-               GetCall(pCS,pCC,u.pRTCP,RxLen);
-
-               if(pCC->bPermanent && !pCC->bConnected) {
-               // A new connection to a permanent connection
-                  pCC->bInConf = TRUE;
-                  pCC->bConnected = TRUE;
-                  IncrementClientCount(pCS,pCC);
-
-                  pCC->LoginTime = TimeNow.tv_sec;
-                  LOG_NORM(("%s%s connected, current users: %d.\n",
-                            CallLog(pCC),pCC->bConf ? " conference" : "",
-                            ConferenceClients));
-                  EndPoint(NULL,pCC,EVENT_INIT);
-                  EventHook("connected outbound %s %d",pCC->Callsign,
-                            ConferenceClients);
-                  pCS->bSendStationList = TRUE;
-               }
-               break;
-
-            case RTCP_BYE:
-               if(pCC->bPermanent && !pCC->bConnected) {
-               // Must be a .connect command that failed. Send the results
-               // to all admins & sysops
-                  p->Count = 0;  // init for BufPrintf
-                  BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-                  BufPrintf(p,"%s refused connection request.\r",pCC->Callsign);
-                  SendToAllSysops(p,pCC->pCS);
-                  LOG_NORM(("%s refused connection request.\n",CallLog(pCC)));
-                  EventHook("disconnected refused %s %d",pCC->Callsign,
-                            ConferenceClients-1);
-               }
-               else {
-                  LOG_NORM(("%s logged out, on %s, current users: %d.\n",
-                            CallLog(pCC),TimeLapse2String(pCC->LoginTime,TRUE),
-                            ConferenceClients-1));
-                  EventHook("disconnected bye %s %d",pCC->Callsign,
-                            ConferenceClients-1);
-               }
-               DeleteCClient(pCC);
-            // Update the station list
-               pCS->bSendStationList = TRUE;
-               return Ret;
-
-            case RTCP_APP:
-               break;
-         }
-         u.cp = u.cp + sizeof(rtcp_common_t) + ntohs(u.p->length) * 4;
+          OpenAudioFile(pCC, WelcomeFile, MODE_RD_BIN);
+          if (pCC->bFileIOActive) {
+            StartPlayback(p, pCC);
+          }
+        }
+      } else if (AudioTestConf && FileRecord(NULL, pCC, EVENT_INIT)) {
+        pCC->bInConf = FALSE;
+        pCC->State = FileRecord;
       }
-   }
+    }
+  } else {
+    pCC->RxBytes += RxLen + HEADER_OVERHEAD;
+    RxBytesAllConf += RxLen + HEADER_OVERHEAD;
+  }
 
-   return Ret;
+  if (pCC != NULL && pCC->bKicked && pCC->bDisconnected) {
+    // maybe he didn't get the news
+    DisconnectCC(p, pCC, "Goodbye");
+  }
+
+  if (pCC != NULL && !pCC->bKicked) {
+    pCC->LastHeard = TimeNow.tv_sec;
+
+    if (pCC->State != NULL) {
+      pCC->State(p, pCC, EVENT_RTCP_RX);
+    }
+
+    Item.p = NULL;
+    end = u.cp + RxLen;
+
+    while (u.cp < end) {
+      D3PRINTF(("RTCP_Rx(): processing pt %d.\n", u.p->pt));
+      switch (u.p->pt) {
+      case RTCP_SR:
+        break;
+
+      case RTCP_RR:
+        break;
+
+      case RTCP_SDES:
+        // Answer with our SDES if he's a new client
+        if (bNewClient) {
+          SendSDES(pCS, pCC);
+        }
+
+        GetCall(pCS, pCC, u.pRTCP, RxLen);
+
+        if (pCC->bPermanent && !pCC->bConnected) {
+          // A new connection to a permanent connection
+          pCC->bInConf = TRUE;
+          pCC->bConnected = TRUE;
+          IncrementClientCount(pCS, pCC);
+
+          pCC->LoginTime = TimeNow.tv_sec;
+          LOG_NORM(("%s%s connected, current users: %d.\n", CallLog(pCC),
+                    pCC->bConf ? " conference" : "", ConferenceClients));
+          EndPoint(NULL, pCC, EVENT_INIT);
+          EventHook("connected outbound %s %d", pCC->Callsign,
+                    ConferenceClients);
+          pCS->bSendStationList = TRUE;
+        }
+        break;
+
+      case RTCP_BYE:
+        if (pCC->bPermanent && !pCC->bConnected) {
+          // Must be a .connect command that failed. Send the results
+          // to all admins & sysops
+          p->Count = 0; // init for BufPrintf
+          BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+          BufPrintf(p, "%s refused connection request.\r", pCC->Callsign);
+          SendToAllSysops(p, pCC->pCS);
+          LOG_NORM(("%s refused connection request.\n", CallLog(pCC)));
+          EventHook("disconnected refused %s %d", pCC->Callsign,
+                    ConferenceClients - 1);
+        } else {
+          LOG_NORM(("%s logged out, on %s, current users: %d.\n", CallLog(pCC),
+                    TimeLapse2String(pCC->LoginTime, TRUE),
+                    ConferenceClients - 1));
+          EventHook("disconnected bye %s %d", pCC->Callsign,
+                    ConferenceClients - 1);
+        }
+        DeleteCClient(pCC);
+        // Update the station list
+        pCS->bSendStationList = TRUE;
+        return Ret;
+
+      case RTCP_APP:
+        break;
+      }
+      u.cp = u.cp + sizeof(rtcp_common_t) + ntohs(u.p->length) * 4;
+    }
+  }
+
+  return Ret;
 }
 
-void SetTimeoutRTCP(ClientInfo *p)
-{
-   ConfServer *pCS = (ConfServer *) p->p;
-   int Timeout = 0x7fffffff;
+void SetTimeoutRTCP(ClientInfo *p) {
+  ConfServer *pCS = (ConfServer *)p->p;
+  int Timeout = 0x7fffffff;
 
-   if(pCS->ConfTree->avl_count > 0) {
-      Timeout = MIN(Timeout,pCS->TimeNextSDES);
-   }
-   
-   if(NextLoginTime != 0) {
-      Timeout = MIN(Timeout,NextLoginTime);
-   }
+  if (pCS->ConfTree->avl_count > 0) {
+    Timeout = MIN(Timeout, pCS->TimeNextSDES);
+  }
 
-   if(NextStationListTime != 0) {
-      Timeout = MIN(Timeout,NextStationListTime);
-   }
+  if (NextLoginTime != 0) {
+    Timeout = MIN(Timeout, NextLoginTime);
+  }
 
-   if(NextAVRSTime != 0) {
-      Timeout = MIN(Timeout,NextAVRSTime);
-   }
+  if (NextStationListTime != 0) {
+    Timeout = MIN(Timeout, NextStationListTime);
+  }
 
-   if(Timeout != 0x7fffffff) {
-      SetTimeout(p,(Timeout - TimeNow.tv_sec) * 1000);
-   }
-   else {
-      p->bTimeWait = FALSE;
-   }
+  if (NextAVRSTime != 0) {
+    Timeout = MIN(Timeout, NextAVRSTime);
+  }
+
+  if (Timeout != 0x7fffffff) {
+    SetTimeout(p, (Timeout - TimeNow.tv_sec) * 1000);
+  } else {
+    p->bTimeWait = FALSE;
+  }
 }
 
-void LogStats(ConfServer *pCS)
-{
-   u_int TxBytes = TxBytesAllConf;
-   u_int TxMBytes = TxMBytesAllConf;
-   u_int RxBytes = RxBytesAllConf;
-   u_int RxMBytes = RxMBytesAllConf;
+void LogStats(ConfServer *pCS) {
+  u_int TxBytes = TxBytesAllConf;
+  u_int TxMBytes = TxMBytesAllConf;
+  u_int RxBytes = RxBytesAllConf;
+  u_int RxMBytes = RxMBytesAllConf;
 
-   CalcBW(pCS,FALSE);
+  CalcBW(pCS, FALSE);
 
-   if(TxBytes > 1000000) {
-      TxMBytes += TxBytes / 1000000;
-      TxBytes %= 1000000;
-   }
+  if (TxBytes > 1000000) {
+    TxMBytes += TxBytes / 1000000;
+    TxBytes %= 1000000;
+  }
 
-   if(RxBytes > 1000000) {
-      RxMBytes += RxBytes / 1000000;
-      RxBytes %= 1000000;
-   }
+  if (RxBytes > 1000000) {
+    RxMBytes += RxBytes / 1000000;
+    RxBytes %= 1000000;
+  }
 
-   LOG_NORM(("Users:%d BW T:%d R:%d T:%d.%02dMB R:%d.%02dMB Up:%s\n",
-             ConferenceClients,pCS->TxBandWidth,pCS->RxBandWidth,
-             TxMBytes,TxBytes*100/1000000,RxMBytes,RxBytes*100/1000000,
-             TimeLapse2String(BootTime,TRUE)));
+  LOG_NORM(("Users:%d BW T:%d R:%d T:%d.%02dMB R:%d.%02dMB Up:%s\n",
+            ConferenceClients, pCS->TxBandWidth, pCS->RxBandWidth, TxMBytes,
+            TxBytes * 100 / 1000000, RxMBytes, RxBytes * 100 / 1000000,
+            TimeLapse2String(BootTime, TRUE)));
 }
 
-void StartCmdHandler(char *Cmd,char *Callsign)
-{
-   ConfServer *pCS = piLinkConf;
-   ClientInfo *p = pCS->pAudio;
-   ConfClient cc;
-   char *cp, *cp1;
+void StartCmdHandler(char *Cmd, char *Callsign) {
+  ConfServer *pCS = piLinkConf;
+  ClientInfo *p = pCS->pAudio;
+  ConfClient cc;
+  char *cp, *cp1;
 
-   if(pCS != NULL) {
-      p = pCS->pAudio;
+  if (pCS != NULL) {
+    p = pCS->pAudio;
 
-      memset(&cc,0,sizeof(cc));
+    memset(&cc, 0, sizeof(cc));
 
-      cc.bCmdLine = TRUE;
-      cc.bSysop = TRUE;
-      cc.bAdmin = TRUE;
-      cc.Callsign = Callsign;
-      cc.CallPlus = cc.Callsign;
-      cc.pCS = pCS;
+    cc.bCmdLine = TRUE;
+    cc.bSysop = TRUE;
+    cc.bAdmin = TRUE;
+    cc.Callsign = Callsign;
+    cc.CallPlus = cc.Callsign;
+    cc.pCS = pCS;
 
-      cp = Cmd;
-      if(*cp == '.') {
-         cp++;
-      }
+    cp = Cmd;
+    if (*cp == '.') {
+      cp++;
+    }
 
-      ConferenceCmd(p,&cc,cp);
-      cp1 = &p->Buf[sizeof(NDATA)];
-      if(strlen(cp1) > 0) {
+    ConferenceCmd(p, &cc, cp);
+    cp1 = &p->Buf[sizeof(NDATA)];
+    if (strlen(cp1) > 0) {
       // log the startup command response
-         while((cp = strchr(cp1,'\r')) != NULL) {
-            *cp++ = 0;
-            LOG_NORM(("StartupCmd: %s\n",cp1));
-            cp1 = cp;
-         }
-
-         if(strlen(cp1) > 0) {
-            LOG_NORM(("StartupCmd: %s\n",cp1));
-         }
+      while ((cp = strchr(cp1, '\r')) != NULL) {
+        *cp++ = 0;
+        LOG_NORM(("StartupCmd: %s\n", cp1));
+        cp1 = cp;
       }
-   }
+
+      if (strlen(cp1) > 0) {
+        LOG_NORM(("StartupCmd: %s\n", cp1));
+      }
+    }
+  }
 }
 
-int CmdLine_Handler(ClientInfo *pClient)
-{
-   ConfServer *pCS = (ConfServer *) pClient->p;
-   ClientInfo *p = pCS->pAudio;
-   socklen_t Adrlen = sizeof(IPAdrUnion);
-   int Ret = FALSE;
-   int bIsCmd = FALSE;
-   int RxLen = SOCKET_ERROR;
-   char  Cmd[CONF_BUF_SIZE];
-   char  *cp;
-   ConfClient *pCC;
-   unsigned short OurPort = ntohs(pClient->HisAdr.PORT);
+int CmdLine_Handler(ClientInfo *pClient) {
+  ConfServer *pCS = (ConfServer *)pClient->p;
+  ClientInfo *p = pCS->pAudio;
+  socklen_t Adrlen = sizeof(IPAdrUnion);
+  int Ret = FALSE;
+  int bIsCmd = FALSE;
+  int RxLen = SOCKET_ERROR;
+  char Cmd[CONF_BUF_SIZE];
+  char *cp;
+  ConfClient *pCC;
+  unsigned short OurPort = ntohs(pClient->HisAdr.PORT);
 
-   for( ; ; ) {
-      if(OurPort == ChatPort) {
-         pCC = &ChatCC;
-      }
-      else if(OurPort == CmdPort) {
-         pCC = &CmdLineCC;
-      }
-      else {
-         LOG_ERROR(("CmdLine_Handler(): Error: unknown port number %d\n",
-                    OurPort));
-         break;
-      }
+  for (;;) {
+    if (OurPort == ChatPort) {
+      pCC = &ChatCC;
+    } else if (OurPort == CmdPort) {
+      pCC = &CmdLineCC;
+    } else {
+      LOG_ERROR(
+          ("CmdLine_Handler(): Error: unknown port number %d\n", OurPort));
+      break;
+    }
 
-      if(pClient->bReadReady) {
-         RxLen = recvfrom(pClient->Socket,Cmd,sizeof(Cmd)-1,0,&pCC->HisAdr.s,
-                          &Adrlen);
-      }
+    if (pClient->bReadReady) {
+      RxLen = recvfrom(pClient->Socket, Cmd, sizeof(Cmd) - 1, 0, &pCC->HisAdr.s,
+                       &Adrlen);
+    }
 
-      if(RxLen == SOCKET_ERROR) {
-         LOG_ERROR(("CmdLine_Handler(): recvfrom failed %s\n",
-                    Err2String(errno)));
-         break;
-      }
+    if (RxLen == SOCKET_ERROR) {
+      LOG_ERROR(("CmdLine_Handler(): recvfrom failed %s\n", Err2String(errno)));
+      break;
+    }
 
-      if(ntohs(pCC->HisAdr.PORT) == OurPort) {
-         LOG_ERROR(("CmdLine_Handler(): I'm talking to myself again!\n"));
-         break;
-      }
+    if (ntohs(pCC->HisAdr.PORT) == OurPort) {
+      LOG_ERROR(("CmdLine_Handler(): I'm talking to myself again!\n"));
+      break;
+    }
 
-      if(ChatCC.HisAdr.PORT == CmdLineCC.HisAdr.PORT) {
+    if (ChatCC.HisAdr.PORT == CmdLineCC.HisAdr.PORT) {
       // We're either running tbdcmd or tbdchat but it appears that we're
       // running both from the same port.  This can happen if we exit
       // one program and start the other and it happens to be assigned the
       // same port number.  Clear the port on the stale client
-         if(OurPort == ChatPort) {
-            CmdLineCC.HisAdr.PORT = 0;
-         }
-         else {
-            ChatCC.HisAdr.PORT = 0;
-         }
+      if (OurPort == ChatPort) {
+        CmdLineCC.HisAdr.PORT = 0;
+      } else {
+        ChatCC.HisAdr.PORT = 0;
       }
+    }
 
-      Cmd[RxLen] = 0;
-      if(bCmdLineChatMode || OurPort == ChatPort) {
-         if(Cmd[0] == '.' && Cmd[1] == '.') {
-            bIsCmd = TRUE;
-         }
+    Cmd[RxLen] = 0;
+    if (bCmdLineChatMode || OurPort == ChatPort) {
+      if (Cmd[0] == '.' && Cmd[1] == '.') {
+        bIsCmd = TRUE;
       }
-      else {
-         bIsCmd = TRUE;
-      }
+    } else {
+      bIsCmd = TRUE;
+    }
 
-      if(bIsCmd) {
-         cp = Cmd;
-         while(*cp == '.') {
-            cp++;
-         }
-         ConferenceCmd(p,pCC,cp);
-      // Strip Text header from result and add result code to the beginning 
+    if (bIsCmd) {
+      cp = Cmd;
+      while (*cp == '.') {
+        cp++;
+      }
+      ConferenceCmd(p, pCC, cp);
+      // Strip Text header from result and add result code to the beginning
       // of the response
-         cp = strdup(&p->Buf[sizeof(NDATA)]);
-         p->Count = snprintf(p->Buf,p->BufSize,"%d\r%s",Rcode,cp);
-         free(cp);
+      cp = strdup(&p->Buf[sizeof(NDATA)]);
+      p->Count = snprintf(p->Buf, p->BufSize, "%d\r%s", Rcode, cp);
+      free(cp);
 
-         if(p->Count == -1 || p->Count >= p->BufSize) {
-         // Pre-C99 style snprintf returns -1 on buffer overflow.  
-         // C99 style snprintf returns the number of characters that would
-         // have been written on buffer overflow.
-         // In either case the output was truncated and p->Count is bogus.
+      if (p->Count == -1 || p->Count >= p->BufSize) {
+        // Pre-C99 style snprintf returns -1 on buffer overflow.
+        // C99 style snprintf returns the number of characters that would
+        // have been written on buffer overflow.
+        // In either case the output was truncated and p->Count is bogus.
 
-            p->Count = p->BufSize - 1;
-            p->Buf[p->Count] = 0;
-         }
-
-         // convert \r end of line convention into *nix standard \n
-
-         cp = p->Buf;
-         while((cp = strchr(cp,'\r')) != NULL) {
-            *cp = '\n';
-         }
+        p->Count = p->BufSize - 1;
+        p->Buf[p->Count] = 0;
       }
-      else {
+
+      // convert \r end of line convention into *nix standard \n
+
+      cp = p->Buf;
+      while ((cp = strchr(cp, '\r')) != NULL) {
+        *cp = '\n';
+      }
+    } else {
       // Format data into an EchoLink text data packet
-         p->Count = 0;  // init for BufPrintf
-         BufPrintf(p,"%c" NDATA "%s>%s\r",ILINK_DATA_PACKET,
-                   ConferenceCall,Cmd);
-         p->Count++;    // include terminating null
-         if(p->Count+4 <= p->BufSize) {
-         // Add SSRC to end of text
-              memcpy(&p->Buf[p->Count],&OurNodeID,4);
-              p->Count += 4;
-         }
-         RTP_Data(p,pCS,pCC);
-         p->Count = snprintf(p->Buf,p->BufSize,"%d\n",TBD_CHAT_TEXT_SENT);
+      p->Count = 0; // init for BufPrintf
+      BufPrintf(p, "%c" NDATA "%s>%s\r", ILINK_DATA_PACKET, ConferenceCall,
+                Cmd);
+      p->Count++; // include terminating null
+      if (p->Count + 4 <= p->BufSize) {
+        // Add SSRC to end of text
+        memcpy(&p->Buf[p->Count], &OurNodeID, 4);
+        p->Count += 4;
       }
-      sendto(pClient->Socket,p->Buf,p->Count+1,0,&pCC->HisAdr.s,
-             sizeof(IPAdrUnion));
-      break;
-   }
+      RTP_Data(p, pCS, pCC);
+      p->Count = snprintf(p->Buf, p->BufSize, "%d\n", TBD_CHAT_TEXT_SENT);
+    }
+    sendto(pClient->Socket, p->Buf, p->Count + 1, 0, &pCC->HisAdr.s,
+           sizeof(IPAdrUnion));
+    break;
+  }
 
-   return Ret;
+  return Ret;
 }
 
-int RTCP_Handler(ClientInfo *p)
-{
-   ConfClient *pCC;
-   ConfClient *pNextCC;
-   ConfClient *pOldestCC = NULL;
-   time_t      OldestConnectTime = 0x7fffffff;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   int Ret = FALSE;
-   static int LastStatsHr = -1;
-   time_t timenow = (time_t) TimeNow.tv_sec;
-   struct tm *tm = localtime(&timenow);
+int RTCP_Handler(ClientInfo *p) {
+  ConfClient *pCC;
+  ConfClient *pNextCC;
+  ConfClient *pOldestCC = NULL;
+  time_t OldestConnectTime = 0x7fffffff;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  int Ret = FALSE;
+  static int LastStatsHr = -1;
+  time_t timenow = (time_t)TimeNow.tv_sec;
+  struct tm *tm = localtime(&timenow);
 
-   if(p->bReadReady) {
-      Ret |= RTCP_Rx(p);
-   }
+  if (p->bReadReady) {
+    Ret |= RTCP_Rx(p);
+  }
 
-   if(LastStatsHr != tm->tm_hour) {
-   // Generate hourly stats while active
-      if(LastStatsHr != -1) {
-         LogStats(pCS);
-      }
-      LastStatsHr = tm->tm_hour;
-   }
-   
-// Check RTCP timeouts
-   pNextCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while((pCC = pNextCC) != NULL) {
-      pNextCC = (ConfClient *) avl_t_next(&avl_trans);
-      if((TimeNow.tv_sec - pCC->LastHeard) > ConfMemberTimeout) {
-         int Clients = ConferenceClients;
+  if (LastStatsHr != tm->tm_hour) {
+    // Generate hourly stats while active
+    if (LastStatsHr != -1) {
+      LogStats(pCS);
+    }
+    LastStatsHr = tm->tm_hour;
+  }
+
+  // Check RTCP timeouts
+  pNextCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while ((pCC = pNextCC) != NULL) {
+    pNextCC = (ConfClient *)avl_t_next(&avl_trans);
+    if ((TimeNow.tv_sec - pCC->LastHeard) > ConfMemberTimeout) {
+      int Clients = ConferenceClients;
       // RTCP timeout
-         if(pCC->bPermanent) {
-            if(pCC->bConnected) {
-               LOG_NORM(("RTCP timeout on permanent client %s. On %s.\n",
-                         CallLog(pCC),TimeLapse2String(pCC->LoginTime,TRUE)));
-               EndPoint(p,pCC,EVENT_RTCP_TO);
-               EventHook("disconnected rtcp_timeout %s %d",pCC->Callsign,
-                         Clients);
-               if(pCC->bConnected) {
-                  pCC->bConnected = FALSE;
-                  ConferenceClients--;
-                  Clients--;
-               }
-               pCC->bInConf = FALSE;
-               pCS->bSendStationList = TRUE;
-            }
-         }
-         else {
-            if(!pCC->bConnected) {
-               LOG_NORM(("Dropping %s. On %s.\n",CallLog(pCC),
-                         TimeLapse2String(pCC->LoginTime,TRUE)));
-            }
-            else {
-               LOG_NORM(("Dropping %s, RTCP timeout. On %s.\n",CallLog(pCC),
-                         TimeLapse2String(pCC->LoginTime,TRUE)));
-               Clients--;
-            }
-            EndPoint(p,pCC,EVENT_RTCP_TO);
-            if(pCC->State != NULL) {
-               pCC->State(p,pCC,EVENT_RTCP_TO);
-            }
-            pCS->bSendStationList = TRUE;
-            EventHook("disconnected rtcp_timeout %s %d",pCC->Callsign,Clients);
-            DeleteCClient(pCC);
-         }
-         continue;
+      if (pCC->bPermanent) {
+        if (pCC->bConnected) {
+          LOG_NORM(("RTCP timeout on permanent client %s. On %s.\n",
+                    CallLog(pCC), TimeLapse2String(pCC->LoginTime, TRUE)));
+          EndPoint(p, pCC, EVENT_RTCP_TO);
+          EventHook("disconnected rtcp_timeout %s %d", pCC->Callsign, Clients);
+          if (pCC->bConnected) {
+            pCC->bConnected = FALSE;
+            ConferenceClients--;
+            Clients--;
+          }
+          pCC->bInConf = FALSE;
+          pCS->bSendStationList = TRUE;
+        }
+      } else {
+        if (!pCC->bConnected) {
+          LOG_NORM(("Dropping %s. On %s.\n", CallLog(pCC),
+                    TimeLapse2String(pCC->LoginTime, TRUE)));
+        } else {
+          LOG_NORM(("Dropping %s, RTCP timeout. On %s.\n", CallLog(pCC),
+                    TimeLapse2String(pCC->LoginTime, TRUE)));
+          Clients--;
+        }
+        EndPoint(p, pCC, EVENT_RTCP_TO);
+        if (pCC->State != NULL) {
+          pCC->State(p, pCC, EVENT_RTCP_TO);
+        }
+        pCS->bSendStationList = TRUE;
+        EventHook("disconnected rtcp_timeout %s %d", pCC->Callsign, Clients);
+        DeleteCClient(pCC);
       }
+      continue;
+    }
 
-      if(pCC->bAutoLurk && !pCC->bLurking && 
-         (TimeNow.tv_sec - pCC->LastAudioIn.tv_sec) > AutoLurkTimeout) {
-         pCC->bLurking = TRUE;
-         pCS->bSendStationList = TRUE;
-         if(!AutoLurk(pCC)) {
-         // Only sent back to lurking message to stations that selected 
-         // lurk mode manually
-            p->Count = 0;  // init for BufPrintf
-            BufPrintf(p,"%c" NDATA "Back to lurking...\r",ILINK_DATA_PACKET);
-            p->Count++; // include terminating null
-            Send2(pCC,p->Buf,p->Count,FALSE);
-         }
+    if (pCC->bAutoLurk && !pCC->bLurking &&
+        (TimeNow.tv_sec - pCC->LastAudioIn.tv_sec) > AutoLurkTimeout) {
+      pCC->bLurking = TRUE;
+      pCS->bSendStationList = TRUE;
+      if (!AutoLurk(pCC)) {
+        // Only sent back to lurking message to stations that selected
+        // lurk mode manually
+        p->Count = 0; // init for BufPrintf
+        BufPrintf(p, "%c" NDATA "Back to lurking...\r", ILINK_DATA_PACKET);
+        p->Count++; // include terminating null
+        Send2(pCC, p->Buf, p->Count, FALSE);
       }
+    }
 
-      if(pCC->bWelcomePending && 
-         (TimeNow.tv_sec - pCC->LoginTime) > WelcomeDelay) 
-      {  // Time to play welcome
-         pCC->bWelcomePending = FALSE;
-         OpenAudioFile(pCC,WelcomeFile,MODE_RD_BIN);
-         if(pCC->bFileIOActive) {
-            StartPlayback(p,pCC);
-         }
+    if (pCC->bWelcomePending && (TimeNow.tv_sec - pCC->LoginTime) >
+                                    WelcomeDelay) { // Time to play welcome
+      pCC->bWelcomePending = FALSE;
+      OpenAudioFile(pCC, WelcomeFile, MODE_RD_BIN);
+      if (pCC->bFileIOActive) {
+        StartPlayback(p, pCC);
       }
+    }
 
-      if(pCC->LoginTime < OldestConnectTime &&
-         strcmp(pCC->Callsign,ConferenceCall) != 0)
-      {
-         OldestConnectTime = pCC->LoginTime;
-         pOldestCC = pCC;
-      }
-   }
+    if (pCC->LoginTime < OldestConnectTime &&
+        strcmp(pCC->Callsign, ConferenceCall) != 0) {
+      OldestConnectTime = pCC->LoginTime;
+      pOldestCC = pCC;
+    }
+  }
 
-   if(p->bTimeOut) {
-      if(LoginInterval > 0 && NextLoginTime <= TimeNow.tv_sec) {
+  if (p->bTimeOut) {
+    if (LoginInterval > 0 && NextLoginTime <= TimeNow.tv_sec) {
       // Time to login again
-         NextLoginTime = TimeNow.tv_sec + LoginInterval;
-         if(NextStationListTime != 0 && NextStationListTime <= TimeNow.tv_sec) {
-         // Also time to refresh the station list
-            NextStationListTime = TimeNow.tv_sec + StationListInterval;
-            DPRINTF(("RTCP_Handler(): refreshing login and station list.\n"));
-            ServerRequest(SERV_REQ_LOGIN_AND_LIST,0,NULL);
-         }
-         else {
-            DPRINTF(("RTCP_Handler(): refreshing login.\n"));
-            ServerRequest(SERV_REQ_LOGIN,0,NULL);
-         }
+      NextLoginTime = TimeNow.tv_sec + LoginInterval;
+      if (NextStationListTime != 0 && NextStationListTime <= TimeNow.tv_sec) {
+        // Also time to refresh the station list
+        NextStationListTime = TimeNow.tv_sec + StationListInterval;
+        DPRINTF(("RTCP_Handler(): refreshing login and station list.\n"));
+        ServerRequest(SERV_REQ_LOGIN_AND_LIST, 0, NULL);
+      } else {
+        DPRINTF(("RTCP_Handler(): refreshing login.\n"));
+        ServerRequest(SERV_REQ_LOGIN, 0, NULL);
       }
-      else if(LoginInterval > 0 && NextStationListTime > 0 && 
-              NextStationListTime <= TimeNow.tv_sec)
-      {
+    } else if (LoginInterval > 0 && NextStationListTime > 0 &&
+               NextStationListTime <= TimeNow.tv_sec) {
       // Time to refresh our station list
-         NextStationListTime = TimeNow.tv_sec + StationListInterval;
-         DPRINTF(("RTCP_Handler(): refreshing station list.\n"));
-         ServerRequest(SERV_REQ_STATION_LIST,0,NULL);
-      }
-      
-      if(pCS->TimeNextSDES <= TimeNow.tv_sec) {
+      NextStationListTime = TimeNow.tv_sec + StationListInterval;
+      DPRINTF(("RTCP_Handler(): refreshing station list.\n"));
+      ServerRequest(SERV_REQ_STATION_LIST, 0, NULL);
+    }
+
+    if (pCS->TimeNextSDES <= TimeNow.tv_sec) {
       // Time to send a SDES to all of our clients
-         D3PRINTF(("Sending SDES to clients\n"));
-         SendSDES2All(p,pCS);
-      }
+      D3PRINTF(("Sending SDES to clients\n"));
+      SendSDES2All(p, pCS);
+    }
 
-      if(pCS->bPlayWhenIdle && 
-         TimeNow.tv_sec - pCS->LastAudioIn.tv_sec > IdleTimeout)
-      {
-         pCS->bPlayWhenIdle = FALSE;
-         StartPlayback(pCS->pAudio,pCS->pFilePlayer);
-      }
+    if (pCS->bPlayWhenIdle &&
+        TimeNow.tv_sec - pCS->LastAudioIn.tv_sec > IdleTimeout) {
+      pCS->bPlayWhenIdle = FALSE;
+      StartPlayback(pCS->pAudio, pCS->pFilePlayer);
+    }
 
-      if(AvrsEnable && pCS->biLinkConf && NextAVRSTime <= TimeNow.tv_sec) {
+    if (AvrsEnable && pCS->biLinkConf && NextAVRSTime <= TimeNow.tv_sec) {
       // Time to send an AVRS update
 
-         NextAVRSTime = TimeNow.tv_sec + AvrsInterval;
-         if(PullerStatusBusy) {
-         // Busy
-            SendAvrsUpdate(AVRS_BUSY,NULL);
-         }
-         else if(pOldestCC != NULL) {
-         // Connected to someone
-            SendAvrsUpdate(AVRS_CONNECTED,pOldestCC->Callsign);
-         }
-         else {
-         // Just hanging out
-            SendAvrsUpdate(AVRS_ON,NULL);
-         }
+      NextAVRSTime = TimeNow.tv_sec + AvrsInterval;
+      if (PullerStatusBusy) {
+        // Busy
+        SendAvrsUpdate(AVRS_BUSY, NULL);
+      } else if (pOldestCC != NULL) {
+        // Connected to someone
+        SendAvrsUpdate(AVRS_CONNECTED, pOldestCC->Callsign);
+      } else {
+        // Just hanging out
+        SendAvrsUpdate(AVRS_ON, NULL);
       }
+    }
 
-#ifdef   LINK_BOX
-      if(AprsIsEnable && LasttAprsIsTime + AprsIsInterval <= TimeNow.tv_sec) {
-         LasttAprsIsTime = TimeNow.tv_sec;
-         if(PullerStatusBusy) {
-         // Busy
-            Send2Aprsd(AVRS_BUSY,NULL);
-         }
-         else if(pOldestCC != NULL) {
-         // Connected to someone
-            Send2Aprsd(AVRS_CONNECTED,pOldestCC->Callsign);
-         }
-         else {
-         // Just hanging out
-            Send2Aprsd(AVRS_ON,NULL);
-         }
+#ifdef LINK_BOX
+    if (AprsIsEnable && LasttAprsIsTime + AprsIsInterval <= TimeNow.tv_sec) {
+      LasttAprsIsTime = TimeNow.tv_sec;
+      if (PullerStatusBusy) {
+        // Busy
+        Send2Aprsd(AVRS_BUSY, NULL);
+      } else if (pOldestCC != NULL) {
+        // Connected to someone
+        Send2Aprsd(AVRS_CONNECTED, pOldestCC->Callsign);
+      } else {
+        // Just hanging out
+        Send2Aprsd(AVRS_ON, NULL);
       }
+    }
 #endif
-   }
-   SetTimeoutRTCP(p);
+  }
+  SetTimeoutRTCP(p);
 
-   if(pCS->bSendStationList) {
-      SendStationList(pCS);
-      pCS->bSendStationList = FALSE;
-   }
+  if (pCS->bSendStationList) {
+    SendStationList(pCS);
+    pCS->bSendStationList = FALSE;
+  }
 
-   if(pCS->bDynamicConf && pCS->Users == 0) {
-      DeleteConf(pCS);
-   }
+  if (pCS->bDynamicConf && pCS->Users == 0) {
+    DeleteConf(pCS);
+  }
 
-   return Ret;
+  return Ret;
 }
 
 // Conference compare by port number
-int ConfCompare(const void *avl_a,const void *avl_b,void *avl_param)
-{
-   ConfServer *p_a = (ConfServer *) avl_a;
-   ConfServer *p_b = (ConfServer *) avl_b;
+int ConfCompare(const void *avl_a, const void *avl_b, void *avl_param) {
+  ConfServer *p_a = (ConfServer *)avl_a;
+  ConfServer *p_b = (ConfServer *)avl_b;
 
-   return p_a->AudioPort - p_b->AudioPort;
+  return p_a->AudioPort - p_b->AudioPort;
 }
 
 // Client compare by IP address : port number
-int CClientCompare(const void *avl_a,const void *avl_b,void *avl_param)
-{
-   ConfClient *p_a = (ConfClient *) avl_a;
-   ConfClient *p_b = (ConfClient *) avl_b;
+int CClientCompare(const void *avl_a, const void *avl_b, void *avl_param) {
+  ConfClient *p_a = (ConfClient *)avl_a;
+  ConfClient *p_b = (ConfClient *)avl_b;
 
-   if(p_a->HisAdr.ADDR == p_b->HisAdr.ADDR) {
-      return p_a->HisAdr.PORT - p_b->HisAdr.PORT;
-   }
+  if (p_a->HisAdr.ADDR == p_b->HisAdr.ADDR) {
+    return p_a->HisAdr.PORT - p_b->HisAdr.PORT;
+  }
 
-   if(p_a->HisAdr.ADDR > p_b->HisAdr.ADDR) {
-      return 1;
-   }
-   else {
-      return -1;
-   }
+  if (p_a->HisAdr.ADDR > p_b->HisAdr.ADDR) {
+    return 1;
+  } else {
+    return -1;
+  }
 }
 
-ConfClient *CreateNewConfClient()
-{
-   ConfClient *pCC = (ConfClient *) malloc(sizeof(ConfClient));
+ConfClient *CreateNewConfClient() {
+  ConfClient *pCC = (ConfClient *)malloc(sizeof(ConfClient));
 
-   if(pCC != NULL) {
-      memset(pCC,0,sizeof(ConfClient));
-      pCC->SN = ++ClientConnects;
-      pCC->bInConf = TRUE;
-   }
-   else {
-      LOG_ERROR(("CreateNewConfClient(): malloc failed.\n"));
-   }
+  if (pCC != NULL) {
+    memset(pCC, 0, sizeof(ConfClient));
+    pCC->SN = ++ClientConnects;
+    pCC->bInConf = TRUE;
+  } else {
+    LOG_ERROR(("CreateNewConfClient(): malloc failed.\n"));
+  }
 
-   return pCC;
+  return pCC;
 }
 
-void RemoveFromStationList(ConfClient *pCC)
-{
-   ConfClient *pCCLast = (ConfClient *) &StationList;
-   ConfClient *pCC1 = StationList;
+void RemoveFromStationList(ConfClient *pCC) {
+  ConfClient *pCCLast = (ConfClient *)&StationList;
+  ConfClient *pCC1 = StationList;
 
-   // Remove him from the station list
+  // Remove him from the station list
 
-   while(pCC1 != NULL) {
-      if(pCC1 == pCC) {
-         pCCLast->Link = pCC->Link;
-         break;
-      }
-      pCCLast = pCC1;
-      pCC1 = pCC1->Link;
-   }
+  while (pCC1 != NULL) {
+    if (pCC1 == pCC) {
+      pCCLast->Link = pCC->Link;
+      break;
+    }
+    pCCLast = pCC1;
+    pCC1 = pCC1->Link;
+  }
 
-   if(pCC1 == NULL && !pCC->bFilePlayer) {
-      LOG_ERROR(("RemoveFromStationList: station %s not found in station list.\n",
-                 inet_ntoa(pCC->HisAdr.i.sin_addr)));
-   }
+  if (pCC1 == NULL && !pCC->bFilePlayer) {
+    LOG_ERROR(("RemoveFromStationList: station %s not found in station list.\n",
+               inet_ntoa(pCC->HisAdr.i.sin_addr)));
+  }
 }
 
-void FileCleanup(ConfClient *pCC)
-{
-   ClientFileIO *pFIO = (ClientFileIO *) pCC->p;
+void FileCleanup(ConfClient *pCC) {
+  ClientFileIO *pFIO = (ClientFileIO *)pCC->p;
 
-   if(pFIO->fp != NULL) {
-      fclose(pFIO->fp);
-   }
+  if (pFIO->fp != NULL) {
+    fclose(pFIO->fp);
+  }
 
-   if(pFIO->pClient != NULL) {
-      pFIO->pClient->Socket = INVALID_SOCKET;
-      DeleteClient(pFIO->pClient);
-   }
+  if (pFIO->pClient != NULL) {
+    pFIO->pClient->Socket = INVALID_SOCKET;
+    DeleteClient(pFIO->pClient);
+  }
 
-   if(pFIO->bDeleteOnClose) {
-      unlink(pFIO->Filename);
-   }
+  if (pFIO->bDeleteOnClose) {
+    unlink(pFIO->Filename);
+  }
 
-   if(pFIO->Filename != NULL) {
-      free(pFIO->Filename);
-   }
+  if (pFIO->Filename != NULL) {
+    free(pFIO->Filename);
+  }
 
-   if(pFIO->pPDat != NULL) {
-      free(pFIO->pPDat);
-   }
+  if (pFIO->pPDat != NULL) {
+    free(pFIO->pPDat);
+  }
 
-   free(pFIO);
-   pCC->p = NULL;
-   pCC->bFileIOActive = FALSE;
+  free(pFIO);
+  pCC->p = NULL;
+  pCC->bFileIOActive = FALSE;
 }
 
-void DeleteCClient(ConfClient *pCC)
-{
-   ConfServer *pCS = pCC->pCS;
-   size_t Nodes = pCS->ConfTree->avl_count;
+void DeleteCClient(ConfClient *pCC) {
+  ConfServer *pCS = pCC->pCS;
+  size_t Nodes = pCS->ConfTree->avl_count;
 
-   EndPoint(NULL,pCC,EVENT_DELETE);
+  EndPoint(NULL, pCC, EVENT_DELETE);
 
-   if(pCC == ClientTalking) {
-      ClientTalking = NULL;
-   }
+  if (pCC == ClientTalking) {
+    ClientTalking = NULL;
+  }
 
-   if(!pCC->bFilePlayer) {
-      if(pCC->bConnected){
-         ConferenceClients--;
-      }
-      gProtoData[pCC->Proto].Clients--;
-      if(ConferenceClients == 0 && AvrsEnable) {
+  if (!pCC->bFilePlayer) {
+    if (pCC->bConnected) {
+      ConferenceClients--;
+    }
+    gProtoData[pCC->Proto].Clients--;
+    if (ConferenceClients == 0 && AvrsEnable) {
       // Force an AVRS update
-         NextAVRSTime = TimeNow.tv_sec;
-      }
-   }
-   RemoveFromStationList(pCC);
+      NextAVRSTime = TimeNow.tv_sec;
+    }
+  }
+  RemoveFromStationList(pCC);
 
-   if(!pCC->bFilePlayer && avl_delete(pCS->ConfTree,pCC) == NULL) {
-      LOG_ERROR(("DeleteCClient: avl_delete() failed to find client.\n"));
-   }
-   else {
-      if(!pCC->bFilePlayer && (Nodes - 1) != pCS->ConfTree->avl_count) {
-         LOG_NORM(("DeleteCClient: %d nodes before delete, %d after\n",Nodes,
-                   pCS->ConfTree->avl_count));
-      }
+  if (!pCC->bFilePlayer && avl_delete(pCS->ConfTree, pCC) == NULL) {
+    LOG_ERROR(("DeleteCClient: avl_delete() failed to find client.\n"));
+  } else {
+    if (!pCC->bFilePlayer && (Nodes - 1) != pCS->ConfTree->avl_count) {
+      LOG_NORM(("DeleteCClient: %d nodes before delete, %d after\n", Nodes,
+                pCS->ConfTree->avl_count));
+    }
 
-      if(pCC->bFileIOActive) {
-         FileCleanup(pCC);
-      }
+    if (pCC->bFileIOActive) {
+      FileCleanup(pCC);
+    }
 
-      if(pCC->CallPlus != NULL) {
-         free(pCC->CallPlus);
-      }
+    if (pCC->CallPlus != NULL) {
+      free(pCC->CallPlus);
+    }
 
-      if(pCC->Callsign != NULL) {
-         free(pCC->Callsign);
-      }
+    if (pCC->Callsign != NULL) {
+      free(pCC->Callsign);
+    }
 
-      if(pCC->Info != NULL) {
-         free(pCC->Info);
-      }
+    if (pCC->Info != NULL) {
+      free(pCC->Info);
+    }
 
-      if(pCC->Password != NULL) {
-         free(pCC->Password);
-      }
+    if (pCC->Password != NULL) {
+      free(pCC->Password);
+    }
 
-      if(pCC->Tool != NULL) {
-         free(pCC->Tool);
-      }
+    if (pCC->Tool != NULL) {
+      free(pCC->Tool);
+    }
 
-      pCC->pCS->Users--;
-      free(pCC);
-   }
+    pCC->pCS->Users--;
+    free(pCC);
+  }
 }
 
 // Sanity check RTCP packet
-// An Speak Freely packet has RTCP_Ver set to 1 in the first chunk, 
+// An Speak Freely packet has RTCP_Ver set to 1 in the first chunk,
 // but set to 2 in the remaining chunks.
 //
 // An standard RTP packet has RTCP_Ver set to 2 in all chunks
@@ -2950,890 +2848,847 @@ void DeleteCClient(ConfClient *pCC)
 // An iLink packet has RTCP_Ver set to 3 in all chunks
 //
 // Return RTCP version or 0 if invalid
-char CheckRTCP(ConfServer *pCS)
-{
-   char *end;
-   union {
-      rtcp_common_t *p;
-      char *cp;
-   } u;
-   rtcp_common_t *p = (rtcp_common_t *) pCS->pControl->Buf;
-   char Ret = 0;
+char CheckRTCP(ConfServer *pCS) {
+  char *end;
+  union {
+    rtcp_common_t *p;
+    char *cp;
+  } u;
+  rtcp_common_t *p = (rtcp_common_t *)pCS->pControl->Buf;
+  char Ret = 0;
 
-   u.p = p;
-   end = u.cp + pCS->pControl->Count;
+  u.p = p;
+  end = u.cp + pCS->pControl->Count;
 
-// Sanity check: Version correct, no padding in first packet,
-// first item is either RTCP_SR or RTCP_RR
+  // Sanity check: Version correct, no padding in first packet,
+  // first item is either RTCP_SR or RTCP_RR
 
-   while(u.cp < end) {
-      if(u.p == p && (p->p || (p->pt != RTCP_SR && p->pt != RTCP_RR)) ){
+  while (u.cp < end) {
+    if (u.p == p && (p->p || (p->pt != RTCP_SR && p->pt != RTCP_RR))) {
       // Invalid RTCP packet
-         LOG_WARN(("CheckRTCP(): First item invalid\n"));
-         break;
-      }
+      LOG_WARN(("CheckRTCP(): First item invalid\n"));
+      break;
+    }
 
-      if(u.p == p && pCS->bSFConf && u.p->version == SF_RTP_VERSION) {
+    if (u.p == p && pCS->bSFConf && u.p->version == SF_RTP_VERSION) {
       // First chunk
-         Ret = SF_RTP_VERSION;
+      Ret = SF_RTP_VERSION;
+    } else if ((pCS->bSFConf || pCS->bRTPConf) && u.p->version == RTP_VERSION) {
+      if (Ret == 0) {
+        Ret = RTP_VERSION;
       }
-      else if((pCS->bSFConf || pCS->bRTPConf) && u.p->version == RTP_VERSION) {
-         if(Ret == 0) {
-            Ret = RTP_VERSION;
-         }
-      }
-      else if(pCS->biLinkConf && u.p->version == ILINK_RTP_VERSION) {
-         Ret = ILINK_RTP_VERSION;
-      }
-      else {
+    } else if (pCS->biLinkConf && u.p->version == ILINK_RTP_VERSION) {
+      Ret = ILINK_RTP_VERSION;
+    } else {
       // Invalid RTCP packet
-         LOG_WARN(("CheckRTCP(): Invalid RTCP version %d\n",u.p->version));
-         Ret = 0;
-         break;
-      }
-      u.cp = u.cp + sizeof(rtcp_common_t) + ntohs(u.p->length) * 4;
-   }
-
-   if(u.cp != end) {
+      LOG_WARN(("CheckRTCP(): Invalid RTCP version %d\n", u.p->version));
       Ret = 0;
-      LOG_WARN(("CheckRTCP(): End of packet mismatch\n"));
-   }
+      break;
+    }
+    u.cp = u.cp + sizeof(rtcp_common_t) + ntohs(u.p->length) * 4;
+  }
 
-   if(Ret == 0) {
-      BadRTCPPacketCount++;
-   }
-   return Ret;
+  if (u.cp != end) {
+    Ret = 0;
+    LOG_WARN(("CheckRTCP(): End of packet mismatch\n"));
+  }
+
+  if (Ret == 0) {
+    BadRTCPPacketCount++;
+  }
+  return Ret;
 }
-      
-int GetCall(ConfServer *pCS,ConfClient *pCC,rtcp_t *p,int len)
-{
-   char *end;
-   char *Temp;
-   char *Callsign = NULL;
-   char *cp;
-   char *TextData = NULL;
-   union {
-      rtcp_common_t *p;
-      rtcp_t *pRTCP;
-      char *cp;
-   } u;
 
-   union {
-      rtcp_sdes_item_t *p;
-      char *cp;
-   } Item;
-   int  bFoundCallsign = TRUE;
-   int  x;
-   int  Ret = FALSE;
-   int  EchoLinkRevMajor;
-   int  EchoLinkRevMinor;
-   int  EchoLinkBuild;
-    
-   Item.p = NULL;
-   u.pRTCP = p;
-   end = u.cp + len;
+int GetCall(ConfServer *pCS, ConfClient *pCC, rtcp_t *p, int len) {
+  char *end;
+  char *Temp;
+  char *Callsign = NULL;
+  char *cp;
+  char *TextData = NULL;
+  union {
+    rtcp_common_t *p;
+    rtcp_t *pRTCP;
+    char *cp;
+  } u;
 
-   while(u.cp < end) {
-      if(u.p->pt == RTCP_SDES) {
+  union {
+    rtcp_sdes_item_t *p;
+    char *cp;
+  } Item;
+  int bFoundCallsign = TRUE;
+  int x;
+  int Ret = FALSE;
+  int EchoLinkRevMajor;
+  int EchoLinkRevMinor;
+  int EchoLinkBuild;
+
+  Item.p = NULL;
+  u.pRTCP = p;
+  end = u.cp + len;
+
+  while (u.cp < end) {
+    if (u.p->pt == RTCP_SDES) {
       // SDES packet
-         Item.p = u.pRTCP->r.sdes.item;
-         Ret = TRUE;
-         break;
+      Item.p = u.pRTCP->r.sdes.item;
+      Ret = TRUE;
+      break;
+    }
+    u.cp = u.cp + sizeof(rtcp_common_t) + ntohs(u.p->length) * 4;
+  }
+
+  while (Item.p != NULL && Item.p->type != RTCP_SDES_END) {
+    switch (Item.p->type) {
+    case RTCP_SDES_CNAME: // CNAME is the only required SDES field
+      if (Item.p->length == 8 && strncmp(Item.p->data, "CALLSIGN", 8) == 0) {
+        bFoundCallsign = TRUE;
       }
-      u.cp = u.cp + sizeof(rtcp_common_t) + ntohs(u.p->length) * 4;
-   }
+      break;
 
-   while(Item.p != NULL && Item.p->type != RTCP_SDES_END) {
-      switch(Item.p->type) {
-         case RTCP_SDES_CNAME:   // CNAME is the only required SDES field
-            if(Item.p->length == 8 && strncmp(Item.p->data,"CALLSIGN",8) == 0) {
-               bFoundCallsign = TRUE;
-            }
-            break;
-         
-         case RTCP_SDES_NAME:
-            if(Item.p->length > 0) {
-               if(Callsign != NULL) {
-               // Two NAME fields !
-                  free(Callsign);
-               }
+    case RTCP_SDES_NAME:
+      if (Item.p->length > 0) {
+        if (Callsign != NULL) {
+          // Two NAME fields !
+          free(Callsign);
+        }
 
-               Temp = malloc(Item.p->length+1);
+        Temp = malloc(Item.p->length + 1);
 
-               if(Temp != NULL) {
-                  memcpy(Temp,Item.p->data,Item.p->length);
-                  Temp[Item.p->length] = 0;
-                  if((cp = strchr(Temp,' ')) != NULL) {
-                  // compress spaces between call and Name
-                     *cp++ = 0;
-                     while(*cp == ' ') {
-                        cp++;
-                     }
-
-                     if(strstr(cp,"conf") != NULL || strstr(cp,"CONF") != NULL) {
-                     // if "conf" appears in the name field it's a conference.
-                        pCC->bConf = TRUE;
-                     }
-
-                     Callsign = malloc(strlen(Temp)+strlen(cp)+2);
-                     if(Callsign != NULL) {
-                        strcpy(Callsign,Temp);
-                        strcat(Callsign," ");
-                        strcat(Callsign,cp);
-                     }
-                     free(Temp);
-                  }
-                  else {
-                  // no spaces to compress
-                     Callsign = Temp;
-                  }
-               }
-            }
-            break;
-
-         case RTCP_SDES_TOOL:
-            x = strlen(PACKAGE);
-            if(Item.p->length > 0 && pCC->Tool == NULL) {
-            // Save the Client's tool name 
-               if((pCC->Tool = malloc(Item.p->length+1)) != NULL) {
-                  memcpy(pCC->Tool,Item.p->data,Item.p->length);
-                  pCC->Tool[Item.p->length] = 0;
-               }
+        if (Temp != NULL) {
+          memcpy(Temp, Item.p->data, Item.p->length);
+          Temp[Item.p->length] = 0;
+          if ((cp = strchr(Temp, ' ')) != NULL) {
+            // compress spaces between call and Name
+            *cp++ = 0;
+            while (*cp == ' ') {
+              cp++;
             }
 
-            if(Item.p->length >= x && strncmp(Item.p->data,PACKAGE,x) == 0) {
-            // One of our guys, set the flags
-               pCC->bConf = pCC->bTBD = pCC->bSendSSRC = TRUE;
+            if (strstr(cp, "conf") != NULL || strstr(cp, "CONF") != NULL) {
+              // if "conf" appears in the name field it's a conference.
+              pCC->bConf = TRUE;
             }
-            else if(Item.p->length > 6 && Item.p->data[0] == 'E') {
-            // Possible EchoLink version
-               Temp = malloc(Item.p->length+1);
 
-               if(Temp != NULL) {
-                  memcpy(Temp,Item.p->data,Item.p->length);
-                  Temp[Item.p->length] = 0;
-                  if(sscanf(&Temp[1],"%d.%d.%d",&EchoLinkRevMajor,
-                            &EchoLinkRevMinor,&EchoLinkBuild) == 3)
-                  { // Yup, it's a (recent) EchoLink client
-                     pCC->bSendSSRC = TRUE;
-                  }
-                  free(Temp);
-               }
+            Callsign = malloc(strlen(Temp) + strlen(cp) + 2);
+            if (Callsign != NULL) {
+              strcpy(Callsign, Temp);
+              strcat(Callsign, " ");
+              strcat(Callsign, cp);
             }
-            break;
-
-         case RTCP_SDES_PHONE:   // We use the phone number field as a password
-            if(RTP_Pass != NULL) {
-               if(pCC->Password != NULL) {
-                  free(pCC->Password);
-               }
-
-               pCC->Password = (char *) malloc(Item.p->length+1);
-
-               if(pCC->Password != NULL) {
-                  memcpy(pCC->Password,Item.p->data,Item.p->length);
-                  pCC->Password[Item.p->length] = 0;
-               }
-            }
-            break;
-
-         case RTCP_SDES_PRIV:
-            if(Item.p->length >= 3 && strncmp(Item.p->data,"txt",3) == 0) {
-            // Our 'talker" or current station
-               pCC->bTxtExtension = TRUE;
-               if(TextData != NULL) {
-                  free(TextData);
-                  TextData = NULL;
-               }
-
-               if(Item.p->length > 3) {
-                  TextData = (char *) malloc(Item.p->length-3+1);
-
-                  if(TextData != NULL) {
-                     memcpy(TextData,&Item.p->data[3],Item.p->length-3);
-                     TextData[Item.p->length-3] = 0;
-                  }
-               }
-            }
-            if(Item.p->length == 5 && strncmp(Item.p->data,FDUPLEX_TEXT,5) == 0) {
-               pCC->bFullDuplex = TRUE;
-               pCC->bSendSSRC = TRUE;
-            }
-            break;
-
-         default:
-            break;
+            free(Temp);
+          } else {
+            // no spaces to compress
+            Callsign = Temp;
+          }
+        }
       }
-      Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-      if(Item.cp >= end) {
+      break;
+
+    case RTCP_SDES_TOOL:
+      x = strlen(PACKAGE);
+      if (Item.p->length > 0 && pCC->Tool == NULL) {
+        // Save the Client's tool name
+        if ((pCC->Tool = malloc(Item.p->length + 1)) != NULL) {
+          memcpy(pCC->Tool, Item.p->data, Item.p->length);
+          pCC->Tool[Item.p->length] = 0;
+        }
+      }
+
+      if (Item.p->length >= x && strncmp(Item.p->data, PACKAGE, x) == 0) {
+        // One of our guys, set the flags
+        pCC->bConf = pCC->bTBD = pCC->bSendSSRC = TRUE;
+      } else if (Item.p->length > 6 && Item.p->data[0] == 'E') {
+        // Possible EchoLink version
+        Temp = malloc(Item.p->length + 1);
+
+        if (Temp != NULL) {
+          memcpy(Temp, Item.p->data, Item.p->length);
+          Temp[Item.p->length] = 0;
+          if (sscanf(&Temp[1], "%d.%d.%d", &EchoLinkRevMajor, &EchoLinkRevMinor,
+                     &EchoLinkBuild) ==
+              3) { // Yup, it's a (recent) EchoLink client
+            pCC->bSendSSRC = TRUE;
+          }
+          free(Temp);
+        }
+      }
+      break;
+
+    case RTCP_SDES_PHONE: // We use the phone number field as a password
+      if (RTP_Pass != NULL) {
+        if (pCC->Password != NULL) {
+          free(pCC->Password);
+        }
+
+        pCC->Password = (char *)malloc(Item.p->length + 1);
+
+        if (pCC->Password != NULL) {
+          memcpy(pCC->Password, Item.p->data, Item.p->length);
+          pCC->Password[Item.p->length] = 0;
+        }
+      }
+      break;
+
+    case RTCP_SDES_PRIV:
+      if (Item.p->length >= 3 && strncmp(Item.p->data, "txt", 3) == 0) {
+        // Our 'talker" or current station
+        pCC->bTxtExtension = TRUE;
+        if (TextData != NULL) {
+          free(TextData);
+          TextData = NULL;
+        }
+
+        if (Item.p->length > 3) {
+          TextData = (char *)malloc(Item.p->length - 3 + 1);
+
+          if (TextData != NULL) {
+            memcpy(TextData, &Item.p->data[3], Item.p->length - 3);
+            TextData[Item.p->length - 3] = 0;
+          }
+        }
+      }
+      if (Item.p->length == 5 && strncmp(Item.p->data, FDUPLEX_TEXT, 5) == 0) {
+        pCC->bFullDuplex = TRUE;
+        pCC->bSendSSRC = TRUE;
+      }
+      break;
+
+    default:
+      break;
+    }
+    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+    if (Item.cp >= end) {
       // bogus packet RTCP_SDES packet
-         BadRTCPPacketCount++;
-         break;
-      }
-   }
+      BadRTCPPacketCount++;
+      break;
+    }
+  }
 
-   if(!bFoundCallsign) {
-      if(Callsign != NULL) {
-         free(Callsign);
-         Callsign = NULL;
-      }
-   // Only accept a password if the callsign is also specified
-      if(pCC->Password != NULL) {
-         free(pCC->Password);
-         pCC->Password = NULL;
-      }
-   }
+  if (!bFoundCallsign) {
+    if (Callsign != NULL) {
+      free(Callsign);
+      Callsign = NULL;
+    }
+    // Only accept a password if the callsign is also specified
+    if (pCC->Password != NULL) {
+      free(pCC->Password);
+      pCC->Password = NULL;
+    }
+  }
 
-   if(Callsign != NULL && pCC->CallPlus != NULL) {
-      if(strcmp(Callsign,pCC->CallPlus) != 0) {
+  if (Callsign != NULL && pCC->CallPlus != NULL) {
+    if (strcmp(Callsign, pCC->CallPlus) != 0) {
       // the callsign/name field has changed
-         if(pCC == ClientTalking) {
-         // This guy is currently talking, force a station list update.
-            pCS->bSendStationList = TRUE;
-         }
+      if (pCC == ClientTalking) {
+        // This guy is currently talking, force a station list update.
+        pCS->bSendStationList = TRUE;
       }
-      else if(TextData == NULL) {
+    } else if (TextData == NULL) {
       // Nothing has changed, nothing to do...
-         if(Callsign != NULL) {
-            free(Callsign);
-            Callsign = NULL;
-         }
-         if(pCC->Password != NULL) {
-            free(pCC->Password);
-            pCC->Password = NULL;
-         }
+      if (Callsign != NULL) {
+        free(Callsign);
+        Callsign = NULL;
       }
-   }
-   
-   if(Callsign != NULL) {
-      if(Callsign[0] == '*') {
-         pCC->bConf = TRUE;
+      if (pCC->Password != NULL) {
+        free(pCC->Password);
+        pCC->Password = NULL;
       }
+    }
+  }
 
-      if((cp = strchr(Callsign,' ')) != NULL) {
+  if (Callsign != NULL) {
+    if (Callsign[0] == '*') {
+      pCC->bConf = TRUE;
+    }
+
+    if ((cp = strchr(Callsign, ' ')) != NULL) {
       // Remove the name from the callsign/name string
-         *cp = 0;
+      *cp = 0;
+    }
+
+    if (!pCC->bCallsignOverride) {
+      if (pCC->Callsign != NULL) {
+        free(pCC->Callsign);
+      }
+      pCC->Callsign = strdup(Callsign);
+
+      if (pCC->CallPlus != NULL) {
+        free(pCC->CallPlus);
       }
 
-      if(!pCC->bCallsignOverride) {
-         if(pCC->Callsign != NULL) {
-            free(pCC->Callsign);
-         }
-         pCC->Callsign = strdup(Callsign);
+      if (TextData != NULL) {
+        // "txt" data was present in SDES, use it
+        pCC->CallPlus = malloc(strlen(Callsign) + strlen(TextData) + 2);
+        if (pCC->CallPlus != NULL) {
+          strcpy(pCC->CallPlus, Callsign);
+          strcat(pCC->CallPlus, " ");
+          strcat(pCC->CallPlus, TextData);
+        }
+      } else {
+        if (cp != NULL) {
+          // Restore the name to the end of the callsign
+          *cp = ' ';
+        }
+        if (pCC->bConf && (cp = strchr(Callsign, ')')) != NULL) {
+          // Remove "CONF" from end of the string
+          cp[1] = 0;
+        }
+        pCC->CallPlus = Callsign;
+      }
+    }
 
-         if(pCC->CallPlus != NULL) {
-            free(pCC->CallPlus);
-         }
+    if (strstr(pCC->Callsign, "-L")) {
+      pCC->bLink = TRUE;
+    } else if (strstr(pCC->Callsign, "-R")) {
+      pCC->bRepeater = TRUE;
+    } else if (pCC->Proto == PROTO_SF) {
+      if (strncmp(pCC->Callsign, "stn", 3) == 0) {
+        pCC->bRepeater = TRUE;
+        pCC->bIRLP = TRUE;
+      } else if (strncmp(pCC->Callsign, "exp", 3) == 0) {
+        pCC->bRepeater = TRUE;
+        pCC->bIRLP = TRUE;
+      } else if (strncmp(pCC->Callsign, "ref", 3) == 0) {
+        pCC->bConf = TRUE;
+        pCC->bIRLP = TRUE;
+      }
+    }
 
-         if(TextData != NULL) {
-         // "txt" data was present in SDES, use it
-            pCC->CallPlus = malloc(strlen(Callsign)+strlen(TextData) + 2);
-            if(pCC->CallPlus != NULL) {
-               strcpy(pCC->CallPlus,Callsign);
-               strcat(pCC->CallPlus," ");
-               strcat(pCC->CallPlus,TextData);
-            }
-         }
-         else {
-            if(cp != NULL) {
-            // Restore the name to the end of the callsign
-               *cp = ' ';
-            }
-            if(pCC->bConf && (cp = strchr(Callsign,')')) != NULL) {
-            // Remove "CONF" from end of the string
-               cp[1] = 0; 
-            }
-            pCC->CallPlus = Callsign;
-         }
-      }
-      
-      if(strstr(pCC->Callsign,"-L")) {
-         pCC->bLink = TRUE;
-      }
-      else if(strstr(pCC->Callsign,"-R")) {
-         pCC->bRepeater = TRUE;
-      }
-      else if(pCC->Proto == PROTO_SF) {
-         if(strncmp(pCC->Callsign,"stn",3) == 0) {
-            pCC->bRepeater = TRUE;
-            pCC->bIRLP = TRUE;
-         }
-         else if(strncmp(pCC->Callsign,"exp",3) == 0) {
-            pCC->bRepeater = TRUE;
-            pCC->bIRLP = TRUE;
-         }
-         else if(strncmp(pCC->Callsign,"ref",3) == 0) {
-            pCC->bConf = TRUE;
-            pCC->bIRLP = TRUE;
-         }
-      }
-
-      if(pCC->bLink || pCC->bRepeater || pCC->bConf) {
+    if (pCC->bLink || pCC->bRepeater || pCC->bConf) {
       // a Potential belcher
-         pCC->bBelcher = TRUE;
-      }
-   }
+      pCC->bBelcher = TRUE;
+    }
+  }
 
-   if(TextData != NULL) {
-      free(TextData);
-   }
+  if (TextData != NULL) {
+    free(TextData);
+  }
 
-   return Ret;
+  return Ret;
 }
 
-char *GetUserCountString()
-{
-   static char Temp[80];
+char *GetUserCountString() {
+  static char Temp[80];
 
-   Temp[0] = 0;
-   if(UserCountEnable) {
-      if(MaxCountEnable) {
-         snprintf(Temp,sizeof(Temp)," [%d/%d]",ConferenceClients,
-                  MaxConferenceClients);
-      }
-      else {
-         snprintf(Temp,sizeof(Temp)," [%d]",ConferenceClients);
-      }
-   }
+  Temp[0] = 0;
+  if (UserCountEnable) {
+    if (MaxCountEnable) {
+      snprintf(Temp, sizeof(Temp), " [%d/%d]", ConferenceClients,
+               MaxConferenceClients);
+    } else {
+      snprintf(Temp, sizeof(Temp), " [%d]", ConferenceClients);
+    }
+  }
 
-   return Temp;
+  return Temp;
 }
 
+void GenStationList(ClientInfo *p) {
+  ConfClient *pCC = StationList;
 
-void GenStationList(ClientInfo *p)
-{
-   ConfClient *pCC = StationList;
-
-   while(pCC != NULL) {
-      if(pCC->bConnected && (!pCC->bLurking || bLurkDisabled)) {
-         if(pCC == ClientTalking) {
-            BufPrintf(p,"->%s\r",pCC->CallPlus);
-         }
-         else if(pCC->bMuted) {
-            BufPrintf(p,"%s (Muted)\r",pCC->Callsign);
-         }
-         else if(pCC->bTimedOut) {
-            BufPrintf(p,"%s (Timed Out)\r",pCC->Callsign);
-         }
-         else if(pCC->bMonitor && strstr(pCC->CallPlus,"(Confer") != NULL) {
-            BufPrintf(p,"%s (Receive only)\r",pCC->Callsign);
-         }
-         else {
-            BufPrintf(p,"%s\r",pCC->CallPlus);
-         }
+  while (pCC != NULL) {
+    if (pCC->bConnected && (!pCC->bLurking || bLurkDisabled)) {
+      if (pCC == ClientTalking) {
+        BufPrintf(p, "->%s\r", pCC->CallPlus);
+      } else if (pCC->bMuted) {
+        BufPrintf(p, "%s (Muted)\r", pCC->Callsign);
+      } else if (pCC->bTimedOut) {
+        BufPrintf(p, "%s (Timed Out)\r", pCC->Callsign);
+      } else if (pCC->bMonitor && strstr(pCC->CallPlus, "(Confer") != NULL) {
+        BufPrintf(p, "%s (Receive only)\r", pCC->Callsign);
+      } else {
+        BufPrintf(p, "%s\r", pCC->CallPlus);
       }
-      pCC = pCC->Link;
-   }
+    }
+    pCC = pCC->Link;
+  }
 }
 
-void SendStationList(ConfServer *pCS)
-{
-   struct avl_traverser avl_trans;
-   ConfClient *pCC;
-   ClientInfo *p = pCS->pAudio;
-   int bSendingInfo = FALSE;
+void SendStationList(ConfServer *pCS) {
+  struct avl_traverser avl_trans;
+  ConfClient *pCC;
+  ClientInfo *p = pCS->pAudio;
+  int bSendingInfo = FALSE;
 
-   p->Count = 0;  // init for BufPrintf
-   BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-   
-   if(ShowStationInfo && 
-      ClientTalking != NULL && 
-      ClientTalking->Info != NULL && 
-      !ClientTalking->bSentInfo) 
-   {  // Show new client's info
-      ClientTalking->bSentInfo = TRUE;
-      bSendingInfo = TRUE;
-      BufPrintf(p,"\rAbout %s:%s",ClientTalking->Callsign,ClientTalking->Info);
-   }
-   else {
-      BufPrintf(p,"CONF %s%s",ConferenceID,GetUserCountString());
-      if(SB_Enable && ClientTalking == NULL) {   
-         BufPrintf(p," <SB>");
-      }
+  p->Count = 0; // init for BufPrintf
+  BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
 
-      BufPrintf(p,"\r\r");
-      GenStationList(p);
+  if (ShowStationInfo && ClientTalking != NULL && ClientTalking->Info != NULL &&
+      !ClientTalking->bSentInfo) { // Show new client's info
+    ClientTalking->bSentInfo = TRUE;
+    bSendingInfo = TRUE;
+    BufPrintf(p, "\rAbout %s:%s", ClientTalking->Callsign, ClientTalking->Info);
+  } else {
+    BufPrintf(p, "CONF %s%s", ConferenceID, GetUserCountString());
+    if (SB_Enable && ClientTalking == NULL) {
+      BufPrintf(p, " <SB>");
+    }
 
-      if(Banner != NULL) {
-         BufPrintf(p,"\r%s\r",Banner);
-      }
-   }
+    BufPrintf(p, "\r\r");
+    GenStationList(p);
 
-   if(p->Count >= sizeof(StatusMsg)) {
-      p->Count = sizeof(StatusMsg) - 1;
-   }
-   p->Buf[p->Count++] = 0;
-   StatusMsgLen = p->Count;
-   memcpy(StatusMsg,p->Buf,StatusMsgLen);
+    if (Banner != NULL) {
+      BufPrintf(p, "\r%s\r", Banner);
+    }
+  }
+
+  if (p->Count >= sizeof(StatusMsg)) {
+    p->Count = sizeof(StatusMsg) - 1;
+  }
+  p->Buf[p->Count++] = 0;
+  StatusMsgLen = p->Count;
+  memcpy(StatusMsg, p->Buf, StatusMsgLen);
 
 #if defined _WIN32GUI || defined _X11GUI
-   UpdateGui(GUIUPDATETYPE_STN,StatusMsg,StatusMsgLen);
+  UpdateGui(GUIUPDATETYPE_STN, StatusMsg, StatusMsgLen);
 #endif
-   
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
 
-   while(pCC != NULL) {
-      if(ClientTalking == NULL) {
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+
+  while (pCC != NULL) {
+    if (ClientTalking == NULL) {
       // Reset everyone's warning flags
-         pCC->bDoublingWarningSent = FALSE;
-         pCC->bPauseWarningSent = FALSE;
-      }
-      else {
-         // Reset everyone's welcome pending flags
-         pCC->bWelcomePending = FALSE;
-      }
-      
-      if(pCC->bInConf && !pCC->bConf && pCC->Proto == PROTO_ILINK) {
-         Send2(pCC,StatusMsg,StatusMsgLen,FALSE);
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+      pCC->bDoublingWarningSent = FALSE;
+      pCC->bPauseWarningSent = FALSE;
+    } else {
+      // Reset everyone's welcome pending flags
+      pCC->bWelcomePending = FALSE;
+    }
+
+    if (pCC->bInConf && !pCC->bConf && pCC->Proto == PROTO_ILINK) {
+      Send2(pCC, StatusMsg, StatusMsgLen, FALSE);
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 }
 
-void GenSDES(int rtp_version,int bTxtExtension)
-{
-   char PadCount;
-   char *pFirstData;
-   char CharSave = 0;
-   time_t timenow = (time_t) TimeNow.tv_sec;
-   struct tm *tm = localtime(&timenow);
-   char *cp, *cp1, *cp2;
-   ConfClient *pCC;
-   char *Talker = NULL;
-   int bConferencing = ConfEnable;
-   union {
-      char *cp;
-      rtcp_t *p;
-   } u;
+void GenSDES(int rtp_version, int bTxtExtension) {
+  char PadCount;
+  char *pFirstData;
+  char CharSave = 0;
+  time_t timenow = (time_t)TimeNow.tv_sec;
+  struct tm *tm = localtime(&timenow);
+  char *cp, *cp1, *cp2;
+  ConfClient *pCC;
+  char *Talker = NULL;
+  int bConferencing = ConfEnable;
+  union {
+    char *cp;
+    rtcp_t *p;
+  } u;
 
-   union {
-      char *cp;
-      rtcp_sdes_item_t *p;
-   } Item;
-   int i = rtp_version - 1;
+  union {
+    char *cp;
+    rtcp_sdes_item_t *p;
+  } Item;
+  int i = rtp_version - 1;
 
-   
-   if(rtp_version != ILINK_RTP_VERSION && OurNodeID == 0) {
-   // Don't generate an SDES for SF or RTP until we have a node number
-      return;
-   }
+  if (rtp_version != ILINK_RTP_VERSION && OurNodeID == 0) {
+    // Don't generate an SDES for SF or RTP until we have a node number
+    return;
+  }
 
-   gProtoData[i].bTxtExtension = bTxtExtension;
-   u.cp = gProtoData[i].OurSDES;
+  gProtoData[i].bTxtExtension = bTxtExtension;
+  u.cp = gProtoData[i].OurSDES;
 
-   u.p->common.version = rtp_version;
-   u.p->common.p = 0;
-   u.p->common.count = 0;
-   u.p->common.pt = RTCP_RR;
-   u.p->common.length = htons(1);
-   u.p->r.rr.ssrc = OurNodeID;
+  u.p->common.version = rtp_version;
+  u.p->common.p = 0;
+  u.p->common.count = 0;
+  u.p->common.pt = RTCP_RR;
+  u.p->common.length = htons(1);
+  u.p->r.rr.ssrc = OurNodeID;
 
-   u.cp += sizeof(u.p->common) + sizeof(u.p->r.rr.ssrc);
+  u.cp += sizeof(u.p->common) + sizeof(u.p->r.rr.ssrc);
 
-   if(rtp_version == SF_RTP_VERSION) {
-   // Only the first RTCP packet is version 1 on Speek freely, the
-   // remaining packets report the standard version
-      rtp_version = RTP_VERSION;
-   }
+  if (rtp_version == SF_RTP_VERSION) {
+    // Only the first RTCP packet is version 1 on Speek freely, the
+    // remaining packets report the standard version
+    rtp_version = RTP_VERSION;
+  }
 
-   u.p->common.version = rtp_version;
-   u.p->common.p = 1;
-   u.p->common.count = 1;
-   u.p->common.pt = RTCP_SDES;
+  u.p->common.version = rtp_version;
+  u.p->common.p = 1;
+  u.p->common.count = 1;
+  u.p->common.pt = RTCP_SDES;
 
-   u.p->r.sdes.src = OurNodeID;
-   pFirstData = (char *) &u.p->r.sdes.src;
+  u.p->r.sdes.src = OurNodeID;
+  pFirstData = (char *)&u.p->r.sdes.src;
 
-   Item.p = &u.p->r.sdes.item[0];
-   Item.p->type = RTCP_SDES_CNAME;
-   Item.p->length = (u_int8) strlen(CallSignString);
-   memcpy(Item.p->data,CallSignString,Item.p->length);
+  Item.p = &u.p->r.sdes.item[0];
+  Item.p->type = RTCP_SDES_CNAME;
+  Item.p->length = (u_int8)strlen(CallSignString);
+  memcpy(Item.p->data, CallSignString, Item.p->length);
 
-   Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-   Item.p->type = RTCP_SDES_NAME;
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  Item.p->type = RTCP_SDES_NAME;
 
-   if(rtp_version == ILINK_RTP_VERSION) {
+  if (rtp_version == ILINK_RTP_VERSION) {
 
-      if((pCC = ClientTalking) != NULL) {
-         cp1 = NULL;
-         cp = strchr(pCC->CallPlus,' ');
+    if ((pCC = ClientTalking) != NULL) {
+      cp1 = NULL;
+      cp = strchr(pCC->CallPlus, ' ');
 
-         if(cp != NULL && cp[1] == '(') {
-            while((cp = strchr(&cp[1],'(')) != NULL) {
-               cp1 = cp;
-            }
-         }
-
-         if(cp1 != NULL && (cp2 = strchr(cp1,')')) != NULL) {
-         // CallPlus plus contains (<stuff>), just pass along the <stuff>
-            CharSave = *cp2;
-            *cp2 = 0;
-            Talker = strdup(&cp1[1]);
-            *cp2 = CharSave;
-         }
-         else {
-            if((cp = strchr(ClientTalking->CallPlus,' ')) != NULL) {
-               while(*cp == ' ') {
-                  cp++;
-               }
-               while(isalnum(*cp)) {
-                  cp++;
-               }
-
-            // truncate name at after first non-alphanumeric character
-               CharSave = *cp;
-               *cp = 0;
-            }
-            Talker = strdup(ClientTalking->CallPlus);
-
-         // restore the original character
-            if(cp != NULL) {
-               *cp = CharSave;
-            }
-         }
+      if (cp != NULL && cp[1] == '(') {
+        while ((cp = strchr(&cp[1], '(')) != NULL) {
+          cp1 = cp;
+        }
       }
 
-      if(SF_Port != SF_ReplyPort) {
+      if (cp1 != NULL && (cp2 = strchr(cp1, ')')) != NULL) {
+        // CallPlus plus contains (<stuff>), just pass along the <stuff>
+        CharSave = *cp2;
+        *cp2 = 0;
+        Talker = strdup(&cp1[1]);
+        *cp2 = CharSave;
+      } else {
+        if ((cp = strchr(ClientTalking->CallPlus, ' ')) != NULL) {
+          while (*cp == ' ') {
+            cp++;
+          }
+          while (isalnum(*cp)) {
+            cp++;
+          }
+
+          // truncate name at after first non-alphanumeric character
+          CharSave = *cp;
+          *cp = 0;
+        }
+        Talker = strdup(ClientTalking->CallPlus);
+
+        // restore the original character
+        if (cp != NULL) {
+          *cp = CharSave;
+        }
+      }
+    }
+
+    if (SF_Port != SF_ReplyPort) {
       // Configured for EchoIRLP
-         if(ConferenceClients < 3) {
-         // EchoIRLP has an internal connection so 2 connections isn't 
-         // really a conference
-            bConferencing = FALSE;
-         }
+      if (ConferenceClients < 3) {
+        // EchoIRLP has an internal connection so 2 connections isn't
+        // really a conference
+        bConferencing = FALSE;
       }
-#ifdef   LINK_BOX
-      else {
-         if(ConferenceClients < 2) {
-            bConferencing = FALSE;
-         }
+    }
+#ifdef LINK_BOX
+    else {
+      if (ConferenceClients < 2) {
+        bConferencing = FALSE;
       }
+    }
 #endif
 
-      if(!bConferencing) {
-         if(UserName != NULL) {
-            sprintf(Item.p->data,"%s %s",ConferenceCall,UserName);
-         }
-         else {
-            strcpy(Item.p->data,ConferenceCall);
-         }
+    if (!bConferencing) {
+      if (UserName != NULL) {
+        sprintf(Item.p->data, "%s %s", ConferenceCall, UserName);
+      } else {
+        strcpy(Item.p->data, ConferenceCall);
       }
-      else if(Talker != NULL) {
-         sprintf(Item.p->data,"%s (%s) CONF",ConferenceCall,Talker);
-      }
-      else {
-         sprintf(Item.p->data,"%s (Conference %s) CONF",ConferenceCall,
-                 GetUserCountString());
-      }
+    } else if (Talker != NULL) {
+      sprintf(Item.p->data, "%s (%s) CONF", ConferenceCall, Talker);
+    } else {
+      sprintf(Item.p->data, "%s (Conference %s) CONF", ConferenceCall,
+              GetUserCountString());
+    }
 
-      Item.p->length = (u_int8) strlen(Item.p->data);
+    Item.p->length = (u_int8)strlen(Item.p->data);
 
-      Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-      Item.p->type = RTCP_SDES_EMAIL;
-      Item.p->length = (u_int8) strlen(CallSignString);
-      memcpy(Item.p->data,CallSignString,Item.p->length);
+    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+    Item.p->type = RTCP_SDES_EMAIL;
+    Item.p->length = (u_int8)strlen(CallSignString);
+    memcpy(Item.p->data, CallSignString, Item.p->length);
 
-      Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-      Item.p->type = RTCP_SDES_PHONE;
-      sprintf(Item.p->data,"%02d:%02d",tm->tm_hour,tm->tm_min);
-      Item.p->length = (u_int8) strlen(Item.p->data);
-   }
-   else {
-   // RTP / Speak freely
-      if(FullName != NULL) {
-         strcpy(Item.p->data,FullName);
-      }
-      else if(UserName != NULL) {
-         sprintf(Item.p->data,"%s %s",ConferenceCall,UserName);
-      }
-      else {
-         strcpy(Item.p->data,ConferenceCall);
-      }
-      Item.p->length = (u_int8) strlen(Item.p->data);
-   }
+    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+    Item.p->type = RTCP_SDES_PHONE;
+    sprintf(Item.p->data, "%02d:%02d", tm->tm_hour, tm->tm_min);
+    Item.p->length = (u_int8)strlen(Item.p->data);
+  } else {
+    // RTP / Speak freely
+    if (FullName != NULL) {
+      strcpy(Item.p->data, FullName);
+    } else if (UserName != NULL) {
+      sprintf(Item.p->data, "%s %s", ConferenceCall, UserName);
+    } else {
+      strcpy(Item.p->data, ConferenceCall);
+    }
+    Item.p->length = (u_int8)strlen(Item.p->data);
+  }
 
-// Set tool item so another conference can identify us as thebridge
-   Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-   Item.p->type = RTCP_SDES_TOOL;
-   sprintf(Item.p->data,PACKAGE " V " VERSION);
+  // Set tool item so another conference can identify us as thebridge
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  Item.p->type = RTCP_SDES_TOOL;
+  sprintf(Item.p->data, PACKAGE " V " VERSION);
 
-   Item.p->length = (u_int8) strlen(Item.p->data);
-   
-   if(rtp_version == ILINK_RTP_VERSION && bTxtExtension && ConfEnable) {
-   // Set 
-      Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-      Item.p->type = RTCP_SDES_PRIV;
-   
-      if(Talker != NULL) {
-         sprintf(Item.p->data,"txt(%s)",Talker);
-      }
-      else {
-         sprintf(Item.p->data,"txt(Conference%s)",GetUserCountString());
-      }
-      Item.p->length = (u_int8) strlen(Item.p->data);
-   }
+  Item.p->length = (u_int8)strlen(Item.p->data);
 
-// enable remote DTMF pad
-   if(EnableRemoteDTMF) {
-      Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-      Item.p->type = RTCP_SDES_PRIV;
-      Item.p->length = 3;
-      memcpy(Item.p->data,"\001D1",3);
-   }
+  if (rtp_version == ILINK_RTP_VERSION && bTxtExtension && ConfEnable) {
+    // Set
+    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+    Item.p->type = RTCP_SDES_PRIV;
 
-   if(FullDuplex) {
-   // We're capable of running full duplex 
-      Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-      Item.p->type = RTCP_SDES_PRIV;
-      Item.p->length = 5;
-      memcpy(Item.p->data,"\003dpx1",5);
-   }
+    if (Talker != NULL) {
+      sprintf(Item.p->data, "txt(%s)", Talker);
+    } else {
+      sprintf(Item.p->data, "txt(Conference%s)", GetUserCountString());
+    }
+    Item.p->length = (u_int8)strlen(Item.p->data);
+  }
 
-   Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-   Item.p->type = RTCP_SDES_END ;
-   Item.p->length = 0;
-   Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  // enable remote DTMF pad
+  if (EnableRemoteDTMF) {
+    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+    Item.p->type = RTCP_SDES_PRIV;
+    Item.p->length = 3;
+    memcpy(Item.p->data, "\001D1", 3);
+  }
 
-   PadCount = 4 - ((Item.cp - pFirstData) % 4);
+  if (FullDuplex) {
+    // We're capable of running full duplex
+    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+    Item.p->type = RTCP_SDES_PRIV;
+    Item.p->length = 5;
+    memcpy(Item.p->data, "\003dpx1", 5);
+  }
 
-   if(PadCount > 0 && PadCount < 4) {
-   // Padding is needed
-      u.p->common.p = 1;
-      if(PadCount > 1) {
-         memset(Item.cp,0,PadCount-1);
-      }
-      Item.cp[PadCount-1] = PadCount;
-      Item.cp += PadCount;
-   }
-   else {
-   // No padding needed
-      u.p->common.p = 0;
-   }
-   u.p->common.length = htons((u_short) ((Item.cp - pFirstData)/4));
-   gProtoData[i].SDESLen = Item.cp - gProtoData[i].OurSDES;
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  Item.p->type = RTCP_SDES_END;
+  Item.p->length = 0;
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
 
-   if(Talker != NULL) {
-      free(Talker);
-   }
+  PadCount = 4 - ((Item.cp - pFirstData) % 4);
+
+  if (PadCount > 0 && PadCount < 4) {
+    // Padding is needed
+    u.p->common.p = 1;
+    if (PadCount > 1) {
+      memset(Item.cp, 0, PadCount - 1);
+    }
+    Item.cp[PadCount - 1] = PadCount;
+    Item.cp += PadCount;
+  } else {
+    // No padding needed
+    u.p->common.p = 0;
+  }
+  u.p->common.length = htons((u_short)((Item.cp - pFirstData) / 4));
+  gProtoData[i].SDESLen = Item.cp - gProtoData[i].OurSDES;
+
+  if (Talker != NULL) {
+    free(Talker);
+  }
 }
 
-int GenBye(ConfClient *pCC,char *Temp,char *Reason)
-{
-   char PadCount;
-   char *pFirstData;
-   char *cp;
+int GenBye(ConfClient *pCC, char *Temp, char *Reason) {
+  char PadCount;
+  char *pFirstData;
+  char *cp;
 
-   union {
-      char *cp;
-      rtcp_t *p;
-   } u;
+  union {
+    char *cp;
+    rtcp_t *p;
+  } u;
 
-   u.cp = Temp;
+  u.cp = Temp;
 
-   u.p->common.version = pCC->Proto + 1;
-   u.p->common.p = 0;
-   u.p->common.count = 0;
-   u.p->common.pt = RTCP_RR;
-   u.p->common.length = htons(1);
-   u.p->r.rr.ssrc = 0;
+  u.p->common.version = pCC->Proto + 1;
+  u.p->common.p = 0;
+  u.p->common.count = 0;
+  u.p->common.pt = RTCP_RR;
+  u.p->common.length = htons(1);
+  u.p->r.rr.ssrc = 0;
 
-   u.cp += sizeof(u.p->common) + sizeof(u.p->r.rr.ssrc);
+  u.cp += sizeof(u.p->common) + sizeof(u.p->r.rr.ssrc);
 
-// NB: SF has version 1 as the in the first chunk, but version 2 in
-// the remaining chunks.
-   u.p->common.version = pCC->Proto == PROTO_ILINK ? 3 : 2;
-   u.p->common.count = 1;
-   u.p->common.pt = RTCP_BYE;
+  // NB: SF has version 1 as the in the first chunk, but version 2 in
+  // the remaining chunks.
+  u.p->common.version = pCC->Proto == PROTO_ILINK ? 3 : 2;
+  u.p->common.count = 1;
+  u.p->common.pt = RTCP_BYE;
 
-   u.p->r.bye.src[0] = OurNodeID;
-   pFirstData = (char *) &u.p->r.bye.src;
-   cp = pFirstData + sizeof(u.p->r.bye.src);
+  u.p->r.bye.src[0] = OurNodeID;
 
-   strcpy(&cp[1],Reason);
+  /*
+   * IMPORTANT:
+   * Don't write the reason into the packed rtcp_t union fields.
+   * Build it into Temp as raw bytes to avoid overflowing the struct.
+   */
+  pFirstData = (char *)&u.p->r.bye.src;
+  cp = pFirstData + sizeof(u.p->r.bye.src);
 
-   *cp = (char) strlen(Reason);
-   cp += *cp + 1;
-   
-   PadCount = 4 - ((cp - pFirstData) % 4);
+  if (Reason && *Reason) {
+    size_t rlen = strlen(Reason);
+    if (rlen > 255)
+      rlen = 255; // RTCP reason length is 1 byte
 
-   if(PadCount > 0 && PadCount < 4) {
-   // Padding is needed
-      u.p->common.p = 1;
-      if(PadCount > 1) {
-         memset(cp,0,PadCount-1);
-      }
-      cp[PadCount-1] = PadCount;
-      cp += PadCount;
-   }
-   else {
-   // No padding needed
-      u.p->common.p = 0;
-   }
-   u.p->common.length = htons((u_short) ((cp - pFirstData)/4));
-   return cp - Temp;
+    cp[0] = (unsigned char)rlen;  // length byte
+    memcpy(&cp[1], Reason, rlen); // reason bytes (no NUL)
+    cp += 1 + rlen;
+  }
+
+  PadCount = 4 - ((cp - pFirstData) % 4);
+
+  if (PadCount > 0 && PadCount < 4) {
+    // Padding is needed
+    u.p->common.p = 1;
+    if (PadCount > 1) {
+      memset(cp, 0, PadCount - 1);
+    }
+    cp[PadCount - 1] = PadCount;
+    cp += PadCount;
+  } else {
+    // No padding needed
+    u.p->common.p = 0;
+  }
+  u.p->common.length = htons((u_short)((cp - pFirstData) / 4));
+  return cp - Temp;
 }
 
 // Convert string to upper case
-void Convert2Upper(char *cp)
-{
-   while(*cp) {
-      *cp = toupper(*cp);
-      cp++;
-   }
+void Convert2Upper(char *cp) {
+  while (*cp) {
+    *cp = toupper(*cp);
+    cp++;
+  }
 }
 
-void SetLurkMode(ClientInfo *p,char *Arg,int bEnable)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
+void SetLurkMode(ClientInfo *p, char *Arg, int bEnable) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
 
-// Try to find a station matching the specified callsign
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(STRCMP(Arg,pCC->Callsign) == 0) {
-         if((pCC->bLurking && !bEnable) || (!pCC->bLurking && bEnable)) {
-            pCC->bLurking = bEnable;
-            pCC->bAutoLurk = bEnable;
-            pCS->bSendStationList = TRUE;
-         }
-         break;
+  // Try to find a station matching the specified callsign
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (STRCMP(Arg, pCC->Callsign) == 0) {
+      if ((pCC->bLurking && !bEnable) || (!pCC->bLurking && bEnable)) {
+        pCC->bLurking = bEnable;
+        pCC->bAutoLurk = bEnable;
+        pCS->bSendStationList = TRUE;
       }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+      break;
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-   if(pCC == NULL) {
-      BufPrintf(p,"Say what?\r");
-   }
+  if (pCC == NULL) {
+    BufPrintf(p, "Say what?\r");
+  }
 }
 
-void CmdLurk(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   ConfServer *pCS = (ConfServer *) p->p;
-   int bLurkModeSet = FALSE;
+void CmdLurk(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  ConfServer *pCS = (ConfServer *)p->p;
+  int bLurkModeSet = FALSE;
 
-   if(pCC->bSysop && *Arg) {
-      if(STRCMP(Arg,"enable") == 0) {
-         bLurkDisabled = FALSE;
-         BufPrintf(p,"Lurking enabled\r");
-      }
-      else if(STRCMP(Arg,"disable") == 0) {
-         bLurkDisabled = TRUE;
-         BufPrintf(p,"Lurking disabled\r");
-      }
-      else {
-         SetLurkMode(p,Arg,TRUE);
-      }
-      bLurkModeSet = TRUE;
-   }
+  if (pCC->bSysop && *Arg) {
+    if (STRCMP(Arg, "enable") == 0) {
+      bLurkDisabled = FALSE;
+      BufPrintf(p, "Lurking enabled\r");
+    } else if (STRCMP(Arg, "disable") == 0) {
+      bLurkDisabled = TRUE;
+      BufPrintf(p, "Lurking disabled\r");
+    } else {
+      SetLurkMode(p, Arg, TRUE);
+    }
+    bLurkModeSet = TRUE;
+  }
 
-   if(!bLurkModeSet) {
-      if(bLurkDisabled) {
-         BufPrintf(p,"Sorry, the administrator of this conference has "
+  if (!bLurkModeSet) {
+    if (bLurkDisabled) {
+      BufPrintf(p, "Sorry, the administrator of this conference has "
                    "disabled the .lurk command\r");
+    } else if (!pCC->bLurking) {
+      pCC->bAutoLurk = TRUE;
+      pCC->bLurking = TRUE;
+      pCS->bSendStationList = TRUE;
+    }
+  }
+}
+
+void CmdDelurk(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  ConfServer *pCS = (ConfServer *)p->p;
+
+  if (pCC->bSysop && *Arg) {
+    SetLurkMode(p, Arg, FALSE);
+  } else {
+    pCC->bLurking = FALSE;
+    pCC->bAutoLurk = FALSE;
+    if (pCC->bLurking) {
+      pCS->bSendStationList = TRUE;
+    }
+  }
+}
+
+void CmdLurkers(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  int Lurkers = 0;
+  ConfServer *pCS = (ConfServer *)p->p;
+
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (pCC->bInConf && pCC->bLurking) {
+      if (Lurkers == 0) {
+        BufPrintf(p, "Lurkers:\r");
       }
-      else if(!pCC->bLurking) {
-         pCC->bAutoLurk = TRUE;
-         pCC->bLurking = TRUE;
-         pCS->bSendStationList = TRUE;
-      }
-   }
+      BufPrintf(p, "%s\r", pCC->CallPlus);
+      Lurkers++;
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+
+  if (Lurkers == 0) {
+    BufPrintf(p, "I see no lurkers here, try down below\r");
+  }
 }
 
-void CmdDelurk(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   ConfServer *pCS = (ConfServer *) p->p;
-
-   if(pCC->bSysop && *Arg) {
-      SetLurkMode(p,Arg,FALSE);
-   }
-   else { 
-      pCC->bLurking = FALSE;
-      pCC->bAutoLurk = FALSE;
-      if(pCC->bLurking) {
-         pCS->bSendStationList = TRUE;
-      }
-   }
+void CmdUpTime(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  BufPrintf(p, "Uptime: %s\r", TimeLapse2String(BootTime, FALSE));
 }
 
-void CmdLurkers(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   int Lurkers = 0;
-   ConfServer *pCS = (ConfServer *) p->p;
-
-
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(pCC->bInConf && pCC->bLurking) {
-         if(Lurkers == 0) {
-            BufPrintf(p,"Lurkers:\r");
-         }
-         BufPrintf(p,"%s\r",pCC->CallPlus);
-         Lurkers++;
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-
-   if(Lurkers == 0) {
-      BufPrintf(p,"I see no lurkers here, try down below\r");
-   }
+void CmdShutdown(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  BufPrintf(p, "Shutting down\r");
+  bShutdown = TRUE;
 }
 
-void CmdUpTime(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   BufPrintf(p,"Uptime: %s\r",TimeLapse2String(BootTime,FALSE));
+void CmdStats(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfServer *pCS = (ConfServer *)p->p;
+  u_int TxBytes = pCS->TxBytes;
+  u_int TxMBytes = pCS->TxMBytes;
+  u_int RxBytes = pCS->RxBytes;
+  u_int RxMBytes = pCS->RxMBytes;
+
+  CalcBW(pCS, FALSE);
+  CmdUpTime(p, pCC1, Arg);
+
+  if (TxBytes > 1000000) {
+    TxMBytes += TxBytes / 1000000;
+    TxBytes %= 1000000;
+  }
+
+  if (RxBytes > 1000000) {
+    RxMBytes += RxBytes / 1000000;
+    RxBytes %= 1000000;
+  }
+
+  BufPrintf(p, "Tx packets: %d, ", pCS->TxCount);
+  BufPrintf(p, "%d.%02d Mbytes\r", TxMBytes, TxBytes * 100 / 1000000);
+  BufPrintf(p, "Rx packets: %d, ", pCS->RxCount);
+  BufPrintf(p, "%d.%02d Mbytes\r", RxMBytes, RxBytes * 100 / 1000000);
+  BufPrintf(p, "Connections: %d\r", ClientConnects);
+
+  BufPrintf(p, "Users: %d of %d Max\r", ConferenceClients,
+            MaxConferenceClients);
+  BufPrintf(p, "Bandwidth Tx: %d Kbps, ", pCS->TxBandWidth);
+  BufPrintf(p, "Rx: %d Kbps\r", pCS->RxBandWidth);
+
+  BufPrintf(p, "Peak users: %d, %s\r", PeakClients,
+            TimeT2String(PeakClientTime));
+  BufPrintf(p, "Peak Tx bandwidth: %d Kbps @ %s\r", pCS->PeakTxBandWidth,
+            TimeT2String(pCS->PeakTxBandWidthTime));
+  BufPrintf(p, "Peak Rx bandwidth: %d Kbps @ %s\r", pCS->PeakRxBandWidth,
+            TimeT2String(pCS->PeakRxBandWidthTime));
 }
 
-void CmdShutdown(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   BufPrintf(p,"Shutting down\r");
-   bShutdown = TRUE;
-}
-
-void CmdStats(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfServer *pCS = (ConfServer *) p->p;
-   u_int TxBytes = pCS->TxBytes;
-   u_int TxMBytes = pCS->TxMBytes;
-   u_int RxBytes = pCS->RxBytes;
-   u_int RxMBytes = pCS->RxMBytes;
-
-
-   CalcBW(pCS,FALSE);
-   CmdUpTime(p,pCC1,Arg);
-
-
-   if(TxBytes > 1000000) {
-      TxMBytes += TxBytes / 1000000;
-      TxBytes %= 1000000;
-   }
-
-   if(RxBytes > 1000000) {
-      RxMBytes += RxBytes / 1000000;
-      RxBytes %= 1000000;
-   }
-
-   BufPrintf(p,"Tx packets: %d, ",pCS->TxCount);
-   BufPrintf(p,"%d.%02d Mbytes\r",TxMBytes,TxBytes*100/1000000);
-   BufPrintf(p,"Rx packets: %d, ",pCS->RxCount);
-   BufPrintf(p,"%d.%02d Mbytes\r",RxMBytes,RxBytes*100/1000000);
-   BufPrintf(p,"Connections: %d\r",ClientConnects);
-
-   BufPrintf(p,"Users: %d of %d Max\r",ConferenceClients,MaxConferenceClients);
-   BufPrintf(p,"Bandwidth Tx: %d Kbps, ",pCS->TxBandWidth);
-   BufPrintf(p,"Rx: %d Kbps\r",pCS->RxBandWidth);
-
-   BufPrintf(p,"Peak users: %d, %s\r",PeakClients,TimeT2String(PeakClientTime));
-   BufPrintf(p,"Peak Tx bandwidth: %d Kbps @ %s\r",pCS->PeakTxBandWidth,
-             TimeT2String(pCS->PeakTxBandWidthTime));
-   BufPrintf(p,"Peak Rx bandwidth: %d Kbps @ %s\r",pCS->PeakRxBandWidth,
-             TimeT2String(pCS->PeakRxBandWidthTime));
-}
-
-void CmdVersion(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   BufPrintf(p,PACKAGE " V " VERSION " on " OUR_HOST "\r");
+void CmdVersion(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  BufPrintf(p, PACKAGE " V " VERSION " on " OUR_HOST "\r");
 }
 
 #ifndef _WIN32
@@ -3842,2250 +3697,2106 @@ extern int SigChilds;
 extern int ChildExits;
 #endif
 
-void CmdDebug(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   int i;
-   ConfServer *pCS = (ConfServer *) p->p;
+void CmdDebug(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  int i;
+  ConfServer *pCS = (ConfServer *)p->p;
 
 #ifndef _WIN32
-   BufPrintf(p,"CallBacksRegistered: %d\r",CallBacksRegistered);
-   BufPrintf(p,"SigChilds: %d\r",SigChilds);
-   BufPrintf(p,"ChildExits: %d\r",ChildExits);
+  BufPrintf(p, "CallBacksRegistered: %d\r", CallBacksRegistered);
+  BufPrintf(p, "SigChilds: %d\r", SigChilds);
+  BufPrintf(p, "ChildExits: %d\r", ChildExits);
 #endif
-   BufPrintf(p,"OpenSockets: %d\r",OpenSockets);
-   BufPrintf(p,"ClientTree entries: %d\r",ClientTree->avl_count);
-   BufPrintf(p,"ConfTree entries: %d\r",pCS->ConfTree->avl_count);
-   BufPrintf(p,"DuplicateClientsDeleted: %d\r",DuplicateClientsDeleted);
-   BufPrintf(p,"Rx errors: %d\r",pCS->RxErrs);
-   BufPrintf(p,"Tx errors: %d\r",pCS->TxErrs);
-   BufPrintf(p,"Bad RTCP packets Rxed: %d\r",BadRTCPPacketCount);
-   BufPrintf(p,"Node #: %d\r",ntohl(OurNodeID));
-   BufPrintf(p,"EchoLink Auth Failures: %d\r",EchoAuthenticationFailures);
-   BufPrintf(p,"EchoLink Auth IP compare failures: %d\r",EchoLinkIPCompareFailures);
-   BufPrintf(p,"Other Auth Failures: %d\r",AuthenticationFailures);
-   BufPrintf(p,"Active Dir entries: %d\r",ActiveDirEntries);
-   BufPrintf(p,"Inactive Dir entries: %d\r",InactiveDirEntries);
-   BufPrintf(p,"BelchTime: %d\r",BelchTime);
-   BufPrintf(p,"PauseTime: %d\r",PauseTime);
-   BufPrintf(p,"BlabOffTimer: %d\r",BlabOffTimer);
-   BufPrintf(p,"ZeroSSRC: %d\r",ZeroSSRC);
-   BufPrintf(p,"EventProcessRunning: %d\r",EventProcessRunning);
-   BufPrintf(p,"DupsReceived: %d\r",pCS->DupsReceived);
-   BufPrintf(p,"DupDisconnects: %d\r",pCS->DupDisconnects);
+  BufPrintf(p, "OpenSockets: %d\r", OpenSockets);
+  BufPrintf(p, "ClientTree entries: %d\r", ClientTree->avl_count);
+  BufPrintf(p, "ConfTree entries: %d\r", pCS->ConfTree->avl_count);
+  BufPrintf(p, "DuplicateClientsDeleted: %d\r", DuplicateClientsDeleted);
+  BufPrintf(p, "Rx errors: %d\r", pCS->RxErrs);
+  BufPrintf(p, "Tx errors: %d\r", pCS->TxErrs);
+  BufPrintf(p, "Bad RTCP packets Rxed: %d\r", BadRTCPPacketCount);
+  BufPrintf(p, "Node #: %d\r", ntohl(OurNodeID));
+  BufPrintf(p, "EchoLink Auth Failures: %d\r", EchoAuthenticationFailures);
+  BufPrintf(p, "EchoLink Auth IP compare failures: %d\r",
+            EchoLinkIPCompareFailures);
+  BufPrintf(p, "Other Auth Failures: %d\r", AuthenticationFailures);
+  BufPrintf(p, "Active Dir entries: %d\r", ActiveDirEntries);
+  BufPrintf(p, "Inactive Dir entries: %d\r", InactiveDirEntries);
+  BufPrintf(p, "BelchTime: %d\r", BelchTime);
+  BufPrintf(p, "PauseTime: %d\r", PauseTime);
+  BufPrintf(p, "BlabOffTimer: %d\r", BlabOffTimer);
+  BufPrintf(p, "ZeroSSRC: %d\r", ZeroSSRC);
+  BufPrintf(p, "EventProcessRunning: %d\r", EventProcessRunning);
+  BufPrintf(p, "DupsReceived: %d\r", pCS->DupsReceived);
+  BufPrintf(p, "DupDisconnects: %d\r", pCS->DupDisconnects);
 
-   BufPrintf(p,"Server: Requested, Succeed, Failed\r");
-   for(i = 0; i < NUM_DIRECTORY_SERVERS; i++) {
-      if(DirServerHost[i] == NULL || ServerStats[i].Requests == 0) {
-         break;
-      }
-      BufPrintf(p,"%s: %d, %d, %d\r",DirServerHost[i],
-                ServerStats[i].Requests,ServerStats[i].Success,
-                ServerStats[i].Failure);
-   }
+  BufPrintf(p, "Server: Requested, Succeed, Failed\r");
+  for (i = 0; i < NUM_DIRECTORY_SERVERS; i++) {
+    if (DirServerHost[i] == NULL || ServerStats[i].Requests == 0) {
+      break;
+    }
+    BufPrintf(p, "%s: %d, %d, %d\r", DirServerHost[i], ServerStats[i].Requests,
+              ServerStats[i].Success, ServerStats[i].Failure);
+  }
 }
 
-void CmdAbout(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
+void CmdAbout(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
 
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(STRCMP(Arg,pCC->Callsign) == 0) {
-         if(pCC->Info != NULL) {
-            BufPrintf(p,"\rAbout %s:%s",pCC->Callsign,pCC->Info);
-         }
-         else {
-            BufPrintf(p,"Sorry I don't know anything about %s.\r",Arg);
-            Rcode = TBD_STATION_NO_INFO;
-         }
-         break;
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (STRCMP(Arg, pCC->Callsign) == 0) {
+      if (pCC->Info != NULL) {
+        BufPrintf(p, "\rAbout %s:%s", pCC->Callsign, pCC->Info);
+      } else {
+        BufPrintf(p, "Sorry I don't know anything about %s.\r", Arg);
+        Rcode = TBD_STATION_NO_INFO;
       }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+      break;
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-   if(pCC == NULL) {
-      BufPrintf(p,"%s not found\r",Arg);
-      Rcode = TBD_STATION_NOT_FOUND;
-   }
+  if (pCC == NULL) {
+    BufPrintf(p, "%s not found\r", Arg);
+    Rcode = TBD_STATION_NOT_FOUND;
+  }
 }
 
-void CmdAdmin(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   if(AdminPass != NULL && STRCMP(AdminPass,Arg) == 0) {
-      pCC->bAdmin = TRUE;
-      pCC->bSysop = TRUE;
-      pCC->bMuted = FALSE;
-      BufPrintf(p,"Your wish is my command.\r");
-      LOG_NORM(("Admin %s logged in\n",pCC->Callsign));
-   }
+void CmdAdmin(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  if (AdminPass != NULL && STRCMP(AdminPass, Arg) == 0) {
+    pCC->bAdmin = TRUE;
+    pCC->bSysop = TRUE;
+    pCC->bMuted = FALSE;
+    BufPrintf(p, "Your wish is my command.\r");
+    LOG_NORM(("Admin %s logged in\n", pCC->Callsign));
+  }
 }
 
-void CmdSysop(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   if(SysopPass != NULL && strcmp(SysopPass,Arg) == 0) {
-      pCC->bSysop = TRUE;
-      pCC->bMuted = FALSE;
-      BufPrintf(p,"By your command.\r");
-      LOG_NORM(("Sysop %s logged in\n",pCC->Callsign));
-   }
+void CmdSysop(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  if (SysopPass != NULL && strcmp(SysopPass, Arg) == 0) {
+    pCC->bSysop = TRUE;
+    pCC->bMuted = FALSE;
+    BufPrintf(p, "By your command.\r");
+    LOG_NORM(("Sysop %s logged in\n", pCC->Callsign));
+  }
 }
 
-void CmdAdmins(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
+void CmdAdmins(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
 
-   BufPrintf(p,"Admins:\r");
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(pCC->bAdmin) {
-         BufPrintf(p,"%s\r",pCC->CallPlus);
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-   BufPrintf(p,"Sysops:\r");
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(!pCC->bAdmin && pCC->bSysop) {
-         BufPrintf(p,"%s\r",pCC->CallPlus);
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+  BufPrintf(p, "Admins:\r");
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (pCC->bAdmin) {
+      BufPrintf(p, "%s\r", pCC->CallPlus);
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+  BufPrintf(p, "Sysops:\r");
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (!pCC->bAdmin && pCC->bSysop) {
+      BufPrintf(p, "%s\r", pCC->CallPlus);
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 }
 
-int SortCClientsByTalkTime(const void *p, const void *p1)
-{
-   return (*(ConfClient **)p1)->LastAudioIn.tv_sec - 
-      (*(ConfClient **)p)->LastAudioIn.tv_sec;
+int SortCClientsByTalkTime(const void *p, const void *p1) {
+  return (*(ConfClient **)p1)->LastAudioIn.tv_sec -
+         (*(ConfClient **)p)->LastAudioIn.tv_sec;
 }
 
-int SortCClientsBySN(const void *p, const void *p1)
-{
-   return (*(ConfClient **)p)->SN - (*(ConfClient **)p1)->SN;
+int SortCClientsBySN(const void *p, const void *p1) {
+  return (*(ConfClient **)p)->SN - (*(ConfClient **)p1)->SN;
 }
 
-void CmdUsers(ClientInfo *p,ConfClient *pCC1,char *Args)
-{
-   struct avl_traverser avl_trans;
-   size_t i = 0;
-   ConfServer *pCS = (ConfServer *) p->p;
-   int CClientsSize = pCS->ConfTree->avl_count * sizeof(ConfClient *);
-   ConfClient **CClients = NULL;
-   ConfClient *pCC;
-   char Line[80];
-   char *cp;
-   char *Arg = Args;
-   int Option = 0;
-   int bDisplayConnectTime = FALSE;
-   int bDisplayTalkTime = FALSE;
-   int bDisplayAttributes = TRUE;
-   int bDisplayTool = FALSE;
-   int bStationList = FALSE;
-   int bSortByTalkTime = FALSE;
-   int BytesLeft;
-   int Len;
+void CmdUsers(ClientInfo *p, ConfClient *pCC1, char *Args) {
+  struct avl_traverser avl_trans;
+  size_t i = 0;
+  ConfServer *pCS = (ConfServer *)p->p;
+  int CClientsSize = pCS->ConfTree->avl_count * sizeof(ConfClient *);
+  ConfClient **CClients = NULL;
+  ConfClient *pCC;
+  char Line[80];
+  char *cp;
+  char *Arg = Args;
+  int Option = 0;
+  int bDisplayConnectTime = FALSE;
+  int bDisplayTalkTime = FALSE;
+  int bDisplayAttributes = TRUE;
+  int bDisplayTool = FALSE;
+  int bStationList = FALSE;
+  int bSortByTalkTime = FALSE;
+  int BytesLeft;
+  int Len;
 
-   while((Option = GetCmdOptions(&Arg,"bcqstTv")) != -1) {
-      switch(Option) {
-         case 'b':   // bare
-            bDisplayAttributes = FALSE;
-            break;
+  while ((Option = GetCmdOptions(&Arg, "bcqstTv")) != -1) {
+    switch (Option) {
+    case 'b': // bare
+      bDisplayAttributes = FALSE;
+      break;
 
-         case 'c':   // display connection time
-            bDisplayConnectTime = TRUE;
-            break;
+    case 'c': // display connection time
+      bDisplayConnectTime = TRUE;
+      break;
 
-         case 'q':   // Quiet - for CGI polling, suppress logging.
-            bLogCmd = FALSE;
-            break;
+    case 'q': // Quiet - for CGI polling, suppress logging.
+      bLogCmd = FALSE;
+      break;
 
-         case 't':   // display time since last transmission
-            bDisplayTalkTime = TRUE;
-            break;
+    case 't': // display time since last transmission
+      bDisplayTalkTime = TRUE;
+      break;
 
-         case 'T':   // sort by time since last transmission
-            bSortByTalkTime = TRUE;
-            break;
+    case 'T': // sort by time since last transmission
+      bSortByTalkTime = TRUE;
+      break;
 
-         case 'v':   // display client's "tool" and version number
-            bDisplayTool = TRUE;
-            break;
+    case 'v': // display client's "tool" and version number
+      bDisplayTool = TRUE;
+      break;
 
-         case 's':   // display station list
-            bStationList = TRUE;
-            break;
+    case 's': // display station list
+      bStationList = TRUE;
+      break;
 
-         case '?':   // invalid switch
-            BufPrintf(p,"Usage:\r");
-            BufPrintf(p,"users [-b] [-c] [-t] [-T] [-v] [?]\r");
-            BufPrintf(p,"  -b - bare (suppress user attributes)\r");
-            BufPrintf(p,"  -c - display time user has been connected\r");
-            BufPrintf(p,"  -q - Quiet (don't log command)\r");
-            BufPrintf(p,"  -t - display time since user last transmitted\r");
-            BufPrintf(p,"  -T - sort by time since last transmission\r");
-            BufPrintf(p,"  -s - display in station list format\r");
-            BufPrintf(p,"  -v - display version number of user's client\r");
-            BufPrintf(p,"  ?  - display User attribute characters\r");
-            break;
+    case '?': // invalid switch
+      BufPrintf(p, "Usage:\r");
+      BufPrintf(p, "users [-b] [-c] [-t] [-T] [-v] [?]\r");
+      BufPrintf(p, "  -b - bare (suppress user attributes)\r");
+      BufPrintf(p, "  -c - display time user has been connected\r");
+      BufPrintf(p, "  -q - Quiet (don't log command)\r");
+      BufPrintf(p, "  -t - display time since user last transmitted\r");
+      BufPrintf(p, "  -T - sort by time since last transmission\r");
+      BufPrintf(p, "  -s - display in station list format\r");
+      BufPrintf(p, "  -v - display version number of user's client\r");
+      BufPrintf(p, "  ?  - display User attribute characters\r");
+      break;
+    }
+  }
+
+  do {
+    if (*Arg == '?') {
+      BufPrintf(p, "User attributes:\r");
+      BufPrintf(p, "0 Speak Freely protocol\r");
+      BufPrintf(p, "1 RTP protocol\r");
+      BufPrintf(p, "7 G.726 codec\r");
+      BufPrintf(p, "A Admin\r");
+      BufPrintf(p, "a ADCPM codec\r");
+      BufPrintf(p, "B theBridge conference\r");
+      BufPrintf(p, "C other conference\r");
+      BufPrintf(p, "c Chat text suppressed\r");
+      BufPrintf(p, "F playing File\r");
+      BufPrintf(p, "f Full duplex\r");
+      BufPrintf(p, "I Isolated (not In conference)\r");
+      BufPrintf(p, "K Kicked\r");
+      BufPrintf(p, "L Lurker\r");
+      BufPrintf(p, "m audio Muted\r");
+      BufPrintf(p, "M audio and text Muted\r");
+      BufPrintf(p, "n Nailed up connection\r");
+      BufPrintf(p, "P Permanent connection\r");
+      BufPrintf(p, "R Receive only (monitored)\r");
+      BufPrintf(p, "S Sysop\r");
+      BufPrintf(p, "t Text muted\r");
+      BufPrintf(p, "T Talking\r");
+      BufPrintf(p, "u uLaw codec\r");
+      BufPrintf(p, "x inactive\r");
+      break;
+    }
+
+    if (bStationList) {
+      GenStationList(p);
+    } else {
+      if ((CClients = malloc(CClientsSize)) == NULL) {
+        LOG_ERROR(("CmdUsers: malloc failed\n"));
+        break;
       }
-   }
-
-   do {
-      if(*Arg == '?') {
-         BufPrintf(p,"User attributes:\r");
-         BufPrintf(p,"0 Speak Freely protocol\r");
-         BufPrintf(p,"1 RTP protocol\r");
-         BufPrintf(p,"7 G.726 codec\r");
-         BufPrintf(p,"A Admin\r");
-         BufPrintf(p,"a ADCPM codec\r");
-         BufPrintf(p,"B theBridge conference\r");
-         BufPrintf(p,"C other conference\r");
-         BufPrintf(p,"c Chat text suppressed\r");
-         BufPrintf(p,"F playing File\r");
-         BufPrintf(p,"f Full duplex\r");
-         BufPrintf(p,"I Isolated (not In conference)\r");
-         BufPrintf(p,"K Kicked\r");
-         BufPrintf(p,"L Lurker\r");
-         BufPrintf(p,"m audio Muted\r");
-         BufPrintf(p,"M audio and text Muted\r");
-         BufPrintf(p,"n Nailed up connection\r");
-         BufPrintf(p,"P Permanent connection\r");
-         BufPrintf(p,"R Receive only (monitored)\r");
-         BufPrintf(p,"S Sysop\r");
-         BufPrintf(p,"t Text muted\r");
-         BufPrintf(p,"T Talking\r");
-         BufPrintf(p,"u uLaw codec\r");
-         BufPrintf(p,"x inactive\r");
-         break;
+      pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+      while (pCC != NULL) {
+        CClients[i++] = pCC;
+        pCC = (ConfClient *)avl_t_next(&avl_trans);
       }
 
-      if(bStationList) {
-         GenStationList(p);
-      }
-      else {
-         if((CClients = malloc(CClientsSize)) == NULL) {
-            LOG_ERROR(("CmdUsers: malloc failed\n"));
-            break;
-         }
-         pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-         while(pCC != NULL) {
-            CClients[i++] = pCC;
-            pCC = (ConfClient *) avl_t_next(&avl_trans);
-         }
+      qsort(CClients, pCS->ConfTree->avl_count, sizeof(ConfClient *),
+            bSortByTalkTime ? SortCClientsByTalkTime : SortCClientsBySN);
 
-         qsort(CClients,pCS->ConfTree->avl_count,sizeof(ConfClient *),
-               bSortByTalkTime? SortCClientsByTalkTime : SortCClientsBySN);
+      for (i = 0; i < pCS->ConfTree->avl_count; i++) {
+        pCC = CClients[i];
+        cp = Line;
+        *cp = 0;
 
-         for(i = 0; i < pCS->ConfTree->avl_count; i++) {
-            pCC = CClients[i];
-            cp = Line;
-            *cp = 0;
+        if (bDisplayAttributes) {
+          if (pCC->bAdmin) {
+            *cp++ = 'A';
+          } else if (pCC->bSysop) {
+            *cp++ = 'S';
+          }
 
-            if(bDisplayAttributes) {
-               if(pCC->bAdmin) {
-                  *cp++ = 'A';
-               }
-               else if(pCC->bSysop) {
-                  *cp++ = 'S';
-               }
+          if (!pCC->bInConf) {
+            *cp++ = 'I';
+          }
 
-               if(!pCC->bInConf) {
-                  *cp++ = 'I';
-               }
+          if (pCC->bLurking) {
+            *cp++ = 'L';
+          } else if (pCC->bAutoLurk) {
+            *cp++ = 'l';
+          }
 
-               if(pCC->bLurking) {
-                  *cp++ = 'L';
-               }
-               else if(pCC->bAutoLurk) {
-                  *cp++ = 'l';
-               }
+          if (pCC->bMuted) {
+            *cp++ = 'm';
+          }
 
-               if(pCC->bMuted) {
-                  *cp++ = 'm';
-               }
+          if (pCC->bSWL) {
+            *cp++ = 'M';
+          }
 
-               if(pCC->bSWL) {
-                  *cp++ = 'M';
-               }
+          if (pCC->bKicked) {
+            *cp++ = 'K';
+          }
 
-               if(pCC->bKicked) {
-                  *cp++ = 'K';
-               }
+          if (pCC->bTBD) {
+            *cp++ = 'B';
+          } else if (pCC->bConf) {
+            *cp++ = 'C';
+          }
 
-               if(pCC->bTBD) {
-                  *cp++ = 'B';
-               }
-               else if(pCC->bConf) {
-                  *cp++ = 'C';
-               }
+          if (pCC->bFileIOActive) {
+            *cp++ = 'F';
+          } else if (!pCC->bConnected) {
+            *cp++ = 'x';
+          }
 
-               if(pCC->bFileIOActive) {
-                  *cp++ = 'F';
-               }
-               else if(!pCC->bConnected) {
-                  *cp++ = 'x';
-               }
+          if (pCC->bPermanent) {
+            *cp++ = 'P';
+          }
 
-               if(pCC->bPermanent) {
-                  *cp++ = 'P';
-               }
+          if (pCC->bTalking) {
+            *cp++ = 'T';
+          }
 
-               if(pCC->bTalking) {
-                  *cp++ = 'T';
-               }
+          if (pCC->bMuteChat) {
+            *cp++ = 't';
+          }
 
-               if(pCC->bMuteChat) {
-                  *cp++ = 't';
-               }
+          else if (pCC->Proto != PROTO_ILINK) {
+            *cp++ = (char)('0' + pCC->Proto);
+          }
 
-               else if(pCC->Proto != PROTO_ILINK) {
-                  *cp++ = (char) ('0' + pCC->Proto);
-               }
+          if (pCC->bNoChat) {
+            *cp++ = 'c';
+          }
 
-               if(pCC->bNoChat) {
-                  *cp++ = 'c';
-               }
+          if (pCC->bMonitor) {
+            *cp++ = 'R';
+          }
 
-               if(pCC->bMonitor) {
-                  *cp++ = 'R';
-               }
+          if (pCC->bTxtExtension) {
+            *cp++ = '!';
+          }
 
-               if(pCC->bTxtExtension) {
-                  *cp++ = '!';
-               }
+          if (pCC->CompressionType == RTP_PT_DVI4_8K) {
+            *cp++ = 'a';
+          }
 
-               if(pCC->CompressionType == RTP_PT_DVI4_8K) {
-                  *cp++ = 'a';
-               }
+          if (pCC->CompressionType == RTP_PT_PCMU) {
+            *cp++ = 'u';
+          }
 
-               if(pCC->CompressionType == RTP_PT_PCMU) {
-                  *cp++ = 'u';
-               }
+          if (pCC->CompressionType == RTP_PT_G726) {
+            *cp++ = '7';
+          }
 
-               if(pCC->CompressionType == RTP_PT_G726) {
-                  *cp++ = '7';
-               }
+          if (pCC->bFullDuplex) {
+            *cp++ = 'f';
+          }
 
-               if(pCC->bFullDuplex) {
-                  *cp++ = 'f';
-               }
+          if (pCC->bNailed) {
+            *cp++ = 'n';
+          }
+        } else if (!pCC->bConnected) {
+          continue;
+        }
 
-               if(pCC->bNailed) {
-                  *cp++ = 'n';
-               }
+        if (bDisplayConnectTime) {
+          BytesLeft = sizeof(Line) - (cp - Line);
+          Len = snprintf(cp, BytesLeft, "%s%s%s",
+                         (bDisplayAttributes && Line[0] != 0) ? ", " : "",
+                         bDisplayAttributes ? "connected: " : "\t",
+                         TimeLapse2String(pCC->LoginTime, TRUE));
+          if (Len != -1 && Len < BytesLeft) {
+            cp += Len;
+          }
+        }
+
+        if (bDisplayTalkTime) {
+          BytesLeft = sizeof(Line) - (cp - Line);
+          if (pCC->FirstAudioIn.tv_sec != 0) {
+            Len = snprintf(cp, BytesLeft, "%s%s%s",
+                           (bDisplayAttributes && Line[0] != 0) ? ", " : "",
+                           bDisplayAttributes ? "last tx: " : "\t",
+                           TimeLapse2String(pCC->LastAudioIn.tv_sec, TRUE));
+            if (Len != -1 && Len < BytesLeft) {
+              cp += Len;
             }
-            else if(!pCC->bConnected) {
-               continue;
-            }
+          }
+        }
 
-            if(bDisplayConnectTime) {
-               BytesLeft = sizeof(Line)-(cp-Line);
-               Len = snprintf(cp,BytesLeft,"%s%s%s",
-                              (bDisplayAttributes && Line[0] != 0) ? ", " : "",
-                              bDisplayAttributes ? "connected: " : "\t",
-                              TimeLapse2String(pCC->LoginTime,TRUE));
-               if(Len != -1 && Len < BytesLeft) {
-                  cp += Len;
-               }
-            }
+        if (bDisplayTool && pCC->Tool != NULL) {
+          BytesLeft = sizeof(Line) - (cp - Line);
+          Len = snprintf(cp, BytesLeft, "%s%s%s",
+                         (bDisplayAttributes && Line[0] != 0) ? ", " : "",
+                         bDisplayAttributes ? "ver: " : "\t", pCC->Tool);
+          if (Len != -1 && Len < BytesLeft) {
+            cp += Len;
+          }
+        }
+        *cp = 0;
 
-            if(bDisplayTalkTime) {
-               BytesLeft = sizeof(Line)-(cp-Line);
-               if(pCC->FirstAudioIn.tv_sec != 0) {
-                  Len = snprintf(cp,BytesLeft,"%s%s%s",
-                                 (bDisplayAttributes && Line[0] != 0) ? ", " : "",
-                                 bDisplayAttributes ? "last tx: " : "\t",
-                                 TimeLapse2String(pCC->LastAudioIn.tv_sec,TRUE));
-                  if(Len != -1 && Len < BytesLeft) {
-                     cp += Len;
-                  }
-               }
-            }
-
-            if(bDisplayTool && pCC->Tool != NULL) {
-               BytesLeft = sizeof(Line)-(cp-Line);
-               Len = snprintf(cp,BytesLeft,"%s%s%s",
-                              (bDisplayAttributes && Line[0] != 0) ? ", " : "",
-                              bDisplayAttributes ? "ver: " : "\t",
-                              pCC->Tool);
-               if(Len != -1 && Len < BytesLeft) {
-                  cp += Len;
-               }
-            }
-            *cp = 0;
-
-            BufPrintf(p,"%d. %s %s\r",i+1,pCC->Callsign,Line);
-         }
-         free(CClients);
-      } while(FALSE);
-   } while(FALSE);
+        BufPrintf(p, "%d. %s %s\r", i + 1, pCC->Callsign, Line);
+      }
+      free(CClients);
+    }
+    while (FALSE)
+      ;
+  } while (FALSE);
 }
 
-void CmdMessage(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfServer *pCS = (ConfServer *) p->p;
-   struct avl_traverser avl_trans;
-   ConfClient *pCC = avl_t_first(&avl_trans,pCS->ConfTree);
+void CmdMessage(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfServer *pCS = (ConfServer *)p->p;
+  struct avl_traverser avl_trans;
+  ConfClient *pCC = avl_t_first(&avl_trans, pCS->ConfTree);
 
-   BufPrintf(p,"%s\r",Arg);
-   p->Count++;
+  BufPrintf(p, "%s\r", Arg);
+  p->Count++;
 
-   while(pCC != NULL) {
-      SendBuf2(p,pCC,FALSE);
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-   SendChatEvent("sent_chat",p->Buf);
+  while (pCC != NULL) {
+    SendBuf2(p, pCC, FALSE);
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+  SendChatEvent("sent_chat", p->Buf);
 
-   p->Count = 0;
-   BufPrintf(p,"%c" NDATA "Message sent\r",ILINK_DATA_PACKET);
+  p->Count = 0;
+  BufPrintf(p, "%c" NDATA "Message sent\r", ILINK_DATA_PACKET);
 }
 
-void CmdMonitor(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   int bMonitor = TRUE;
+void CmdMonitor(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  int bMonitor = TRUE;
 
-   if(strstr(Arg,"disable") == Arg) {
-      bMonitor = FALSE;
-      while(*Arg && *Arg != ' ') {
-         Arg++;
+  if (strstr(Arg, "disable") == Arg) {
+    bMonitor = FALSE;
+    while (*Arg && *Arg != ' ') {
+      Arg++;
+    }
+
+    while (*Arg && *Arg == ' ') {
+      Arg++;
+    }
+  }
+
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (STRCMP(Arg, pCC->Callsign) == 0) {
+      pCC->bMonitor = bMonitor;
+      if (bMonitor) {
+        BufPrintf(p, "Monitoring %s\r", Arg);
+      } else {
+        BufPrintf(p, "transmit enabled to %s\r", Arg);
       }
+      break;
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-      while(*Arg && *Arg == ' ') {
-         Arg++;
-      }
-   }
-
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(STRCMP(Arg,pCC->Callsign) == 0) {
-         pCC->bMonitor = bMonitor;
-         if(bMonitor) {
-            BufPrintf(p,"Monitoring %s\r",Arg);
-         }
-         else {
-            BufPrintf(p,"transmit enabled to %s\r",Arg);
-         }
-         break;
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-
-   if(*Arg == 0) {
-   // No argument
-      BufPrintf(p,"Usage:\r");
-      BufPrintf(p,"monitor <call>\r");
-      BufPrintf(p,"monitor disable <call>\r");
-   }
-   else if(pCC == NULL) {
-      BufPrintf(p,"%s not found\r",Arg);
-      Rcode = TBD_STATION_NOT_FOUND;
-   }
+  if (*Arg == 0) {
+    // No argument
+    BufPrintf(p, "Usage:\r");
+    BufPrintf(p, "monitor <call>\r");
+    BufPrintf(p, "monitor disable <call>\r");
+  } else if (pCC == NULL) {
+    BufPrintf(p, "%s not found\r", Arg);
+    Rcode = TBD_STATION_NOT_FOUND;
+  }
 }
 
 //  "lookup"  <callsign>
-void CmdLookUp(ClientInfo *p,ConfClient *pCC,char *Arg) 
-{
-   UserInfo UserLookup;
-   UserInfo *pUser = NULL;
+void CmdLookUp(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  UserInfo UserLookup;
+  UserInfo *pUser = NULL;
 
-   char *Callsign = NULL;
-   char *cp = Arg;
-   char  *WhiteSpace = "\t\n ";
+  char *Callsign = NULL;
+  char *cp = Arg;
+  char *WhiteSpace = "\t\n ";
 
-   if((Callsign = strtok(cp,WhiteSpace)) == NULL) {
-      BufPrintf(p,"Usage: lookup <callsign>\r");
-      Rcode = TBD_ERR_INVALID_ARG;
-   }
+  if ((Callsign = strtok(cp, WhiteSpace)) == NULL) {
+    BufPrintf(p, "Usage: lookup <callsign>\r");
+    Rcode = TBD_ERR_INVALID_ARG;
+  }
 
-   if(Rcode == 0) {
-      Convert2Upper(Callsign);        
-      UserLookup.Callsign = Callsign;
-      if((pUser = avl_find(UserTree,&UserLookup)) != NULL) {
-         BufPrintf(p,"Callsign:%s \r"
-                   "NodeID:%d \r"
-                   "Qth:%s \r"
-                   "%s \r",
-                   pUser->Callsign,
-                   pUser->NodeID,
-                   pUser->Qth,
-                   pUser->bBusy?"Busy":"Not Busy");        
-      }
-      else {
-         BufPrintf(p,"Station \"%s\" not found.\r",Callsign);
-         Rcode = TBD_STATION_NOT_FOUND;
-      }  
-   }
+  if (Rcode == 0) {
+    Convert2Upper(Callsign);
+    UserLookup.Callsign = Callsign;
+    if ((pUser = avl_find(UserTree, &UserLookup)) != NULL) {
+      BufPrintf(p,
+                "Callsign:%s \r"
+                "NodeID:%d \r"
+                "Qth:%s \r"
+                "%s \r",
+                pUser->Callsign, pUser->NodeID, pUser->Qth,
+                pUser->bBusy ? "Busy" : "Not Busy");
+    } else {
+      BufPrintf(p, "Station \"%s\" not found.\r", Callsign);
+      Rcode = TBD_STATION_NOT_FOUND;
+    }
+  }
 }
 
 // "mute" | "unmute" [-u][-c][-t][-a][-p] [.] [-x][<callsign> ...] [chat]
-void CmdMuteCommon(ClientInfo *p,ConfClient *pCC1,char *Arg,int bMute)
-{
-   #define MAX_MUTE_CALLS  32
-   ConfClient *pCC = NULL;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   int bDoConf = FALSE;
-   int bDoTBD = FALSE;
-   int bDoUsers = FALSE;
-   int bDoSyops = FALSE;
-   int bDoRF = FALSE;
-   int bDoTalker = FALSE;
-   int bDidTalker = FALSE;
-   int bDoList = FALSE;
-   int bDidit = FALSE;
-   int bDoUsage = FALSE;
-   int bDidChat = FALSE;
-   int bMuteChat = FALSE;
-   int bPersistent = FALSE;
-   int PersistentCalls = 0;
-   int bByCall = FALSE;
-   int bDoIt;
-   int NumCalls = 0;
-   int CallsFound = 0;
-   char *Calls[MAX_MUTE_CALLS];
-   int CallFound[MAX_MUTE_CALLS];
-   int OptionsFound = 0;
-   char *Sep = "";
-   char *SetSep;
-   char *MsgStart = &p->Buf[p->Count];
-   int i;
-   UserInfo UserLookup;
-   UserInfo *pUser;
+void CmdMuteCommon(ClientInfo *p, ConfClient *pCC1, char *Arg, int bMute) {
+#define MAX_MUTE_CALLS 32
+  ConfClient *pCC = NULL;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  int bDoConf = FALSE;
+  int bDoTBD = FALSE;
+  int bDoUsers = FALSE;
+  int bDoSyops = FALSE;
+  int bDoRF = FALSE;
+  int bDoTalker = FALSE;
+  int bDidTalker = FALSE;
+  int bDoList = FALSE;
+  int bDidit = FALSE;
+  int bDoUsage = FALSE;
+  int bDidChat = FALSE;
+  int bMuteChat = FALSE;
+  int bPersistent = FALSE;
+  int PersistentCalls = 0;
+  int bByCall = FALSE;
+  int bDoIt;
+  int NumCalls = 0;
+  int CallsFound = 0;
+  char *Calls[MAX_MUTE_CALLS];
+  int CallFound[MAX_MUTE_CALLS];
+  int OptionsFound = 0;
+  char *Sep = "";
+  char *SetSep;
+  char *MsgStart = &p->Buf[p->Count];
+  int i;
+  UserInfo UserLookup;
+  UserInfo *pUser;
 
-   memset(CallFound,0,sizeof(CallFound));
+  memset(CallFound, 0, sizeof(CallFound));
 
-   if(*Arg == 0) {
-   // No argument
-      bDoList = TRUE;
-   }
-   else while(*Arg) {
-      while(*Arg == ' ') {
-      // Skip spaces between arguments
-         Arg++;
+  if (*Arg == 0) {
+    // No argument
+    bDoList = TRUE;
+  } else
+    while (*Arg) {
+      while (*Arg == ' ') {
+        // Skip spaces between arguments
+        Arg++;
       }
-      
-      if(*Arg == '-') {
-      // switch
-         Arg++;
-         OptionsFound++;
-         while(*Arg && *Arg != ' ') {
-            switch(tolower(*Arg)) {
-               case 'a':
-                  bDoTBD = bDoConf = bDoUsers = bDoSyops = bDoRF = TRUE;
-                  bDoTalker = TRUE;
-                  pCS->bMuteTBD = pCS->bMuteRF = pCS->bMuteConf = bMute;
-                  pCS->bMuteUsers = bMute;
-                  bDidit = TRUE;
-                  break;
-               
-               case 'c':
-                  pCS->bMuteTBD = bMute;
-                  bDoTBD = TRUE;
-                  bDidit = TRUE;
-                  break;
 
-               case 'e':
-                  pCS->bMuteConf = bMute;
-                  bDoConf = TRUE;
-                  bDidit = TRUE;
-                  break;
-
-               case 'p':
-                  bPersistent = TRUE;
-                  break;
-
-               case 'r':
-                  pCS->bMuteRF = bMute;
-                  bDoRF = TRUE;
-                  bDidit = TRUE;
-                  break;
-
-               case 's':
-                  bDoSyops = TRUE;
-                  break;
-
-               case 'u':
-                  pCS->bMuteUsers = bMute;
-                  bDoUsers = TRUE;
-                  bDidit = TRUE;
-                  break;
-               
-               case 'x':   // inbound Chat
-                  bMuteChat = TRUE;
-                  break;
-
-               case 't':
-               case '.':
-                  if(bMute) {
-                     bDoTalker = TRUE;
-                     break;
-                  }
-               // intentional fall thru to default case if unmute command
-               
-               default:
-               // Unknown switch
-                  BufPrintf(p,"Error: unknown option \"%c\".\r",*Arg);
-               // intentional fall thru to 'h' case
-
-               case 'h':
-                  Arg = " ";
-                  bDoUsage = TRUE;
-                  break;
-            }
-            Arg++;
-         }
-      }
-      else if(*Arg == '?') {
-         bDoUsage = TRUE;
-         break;
-      }
-      else if(strncmp(Arg,"chat",4) == 0) {
-      // Mute/UnMute chat command
-         OptionsFound++;
-         pCC1->bNoChat = bMute;
-         bDidit = TRUE;
-         bDidChat = TRUE;
-         Arg += 4;
-      }
-      else if(*Arg == '.') {
-         if(bMute) {
-            OptionsFound++;
+      if (*Arg == '-') {
+        // switch
+        Arg++;
+        OptionsFound++;
+        while (*Arg && *Arg != ' ') {
+          switch (tolower(*Arg)) {
+          case 'a':
+            bDoTBD = bDoConf = bDoUsers = bDoSyops = bDoRF = TRUE;
             bDoTalker = TRUE;
-            Arg++;
-         }
-         else {
-         // No '.' option to the unmute command
+            pCS->bMuteTBD = pCS->bMuteRF = pCS->bMuteConf = bMute;
+            pCS->bMuteUsers = bMute;
+            bDidit = TRUE;
+            break;
+
+          case 'c':
+            pCS->bMuteTBD = bMute;
+            bDoTBD = TRUE;
+            bDidit = TRUE;
+            break;
+
+          case 'e':
+            pCS->bMuteConf = bMute;
+            bDoConf = TRUE;
+            bDidit = TRUE;
+            break;
+
+          case 'p':
+            bPersistent = TRUE;
+            break;
+
+          case 'r':
+            pCS->bMuteRF = bMute;
+            bDoRF = TRUE;
+            bDidit = TRUE;
+            break;
+
+          case 's':
+            bDoSyops = TRUE;
+            break;
+
+          case 'u':
+            pCS->bMuteUsers = bMute;
+            bDoUsers = TRUE;
+            bDidit = TRUE;
+            break;
+
+          case 'x': // inbound Chat
+            bMuteChat = TRUE;
+            break;
+
+          case 't':
+          case '.':
+            if (bMute) {
+              bDoTalker = TRUE;
+              break;
+            }
+            // intentional fall thru to default case if unmute command
+
+          default:
+            // Unknown switch
+            BufPrintf(p, "Error: unknown option \"%c\".\r", *Arg);
+            // intentional fall thru to 'h' case
+
+          case 'h':
+            Arg = " ";
             bDoUsage = TRUE;
             break;
-         }
+          }
+          Arg++;
+        }
+      } else if (*Arg == '?') {
+        bDoUsage = TRUE;
+        break;
+      } else if (strncmp(Arg, "chat", 4) == 0) {
+        // Mute/UnMute chat command
+        OptionsFound++;
+        pCC1->bNoChat = bMute;
+        bDidit = TRUE;
+        bDidChat = TRUE;
+        Arg += 4;
+      } else if (*Arg == '.') {
+        if (bMute) {
+          OptionsFound++;
+          bDoTalker = TRUE;
+          Arg++;
+        } else {
+          // No '.' option to the unmute command
+          bDoUsage = TRUE;
+          break;
+        }
+      } else {
+        // Assume it's a callsign
+        OptionsFound++;
+        Calls[NumCalls++] = Arg;
+        // Skip to end of callsign
+        while (*Arg && *Arg != ' ') {
+          Arg++;
+        }
+        if (*Arg) {
+          *Arg++ = 0;
+        }
+        if (NumCalls == MAX_MUTE_CALLS) {
+          // Callsign list full (!)
+          break;
+        }
       }
-      else {
-      // Assume it's a callsign
-         OptionsFound++;
-         Calls[NumCalls++] = Arg;
-      // Skip to end of callsign
-         while(*Arg && *Arg != ' ') {
-            Arg++;
-         }
-         if(*Arg) {
-            *Arg++ = 0;
-         }
-         if(NumCalls == MAX_MUTE_CALLS) {
-         // Callsign list full (!)
-            break;
-         }
-      }
-   }
+    }
 
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(!bDoUsage && pCC != NULL) {
-      bDoIt = bByCall = FALSE;
-      if(bDoList && bMute) {
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (!bDoUsage && pCC != NULL) {
+    bDoIt = bByCall = FALSE;
+    if (bDoList && bMute) {
       // No argument to mute command - list muted stations
-         if(pCC->bMuted) {
-            bDidit = TRUE;
-            BufPrintf(p,"%s\r",pCC->Callsign);
-         }
+      if (pCC->bMuted) {
+        bDidit = TRUE;
+        BufPrintf(p, "%s\r", pCC->Callsign);
       }
+    }
 
-      if(bDoTalker && pCC == ClientTalking && !bDoConf) {
+    if (bDoTalker && pCC == ClientTalking && !bDoConf) {
       // Mute station current talking
-         if(ClientTalking->bConf) {
-         // The guy talking is on another conference, send a .mute
-         // command to that conference
-            BufPrintf(p,"%s>%s\r",ConferenceCall,".mute %s.",
-                      bMuteChat ? "-x " : "");
-            Send2(ClientTalking,p->Buf,p->Count,FALSE);
-            p->Count = 0;  // init for BufPrintf
-            BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-            BufPrintf(p,"Mute command sent to %s\r",ClientTalking->Callsign);
-            bDidit = TRUE; // message sent
-         }
-         else if(pCC1 == ClientTalking) {
-         // Don't allow someone mute himself by accident
-            if(!pCC1->bConf) {
-               BufPrintf(p,"Just stop talking to mute yourself!\r");
-            }
-         }
-         else {
-            bDidTalker = bDoIt = TRUE;
-            ClientTalking = NULL;
-         }
+      if (ClientTalking->bConf) {
+        // The guy talking is on another conference, send a .mute
+        // command to that conference
+        BufPrintf(p, "%s>%s\r", ConferenceCall, ".mute %s.",
+                  bMuteChat ? "-x " : "");
+        Send2(ClientTalking, p->Buf, p->Count, FALSE);
+        p->Count = 0; // init for BufPrintf
+        BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+        BufPrintf(p, "Mute command sent to %s\r", ClientTalking->Callsign);
+        bDidit = TRUE; // message sent
+      } else if (pCC1 == ClientTalking) {
+        // Don't allow someone mute himself by accident
+        if (!pCC1->bConf) {
+          BufPrintf(p, "Just stop talking to mute yourself!\r");
+        }
+      } else {
+        bDidTalker = bDoIt = TRUE;
+        ClientTalking = NULL;
       }
-      
-      if((!pCC->bSysop || bDoSyops || !bMute) && 
-         (pCC != pCC1 || !bMute) &&
-         (pCC != ClientTalking || bDoTalker) &&
-         (
-            (bDoTBD && pCC->bTBD) ||
-            (bDoConf && pCC->bConf && !pCC->bTBD) ||
-            (bDoUsers && !(pCC->bLink || pCC->bRepeater || pCC->bConf)) ||
-            (bDoSyops && pCC->bSysop) ||
-            (bDoRF && (pCC->bLink || pCC->bRepeater)) ||
-            (bDoTalker && pCC == ClientTalking)
-         ))
-      {
-         bDoIt = TRUE;
-      }
-      
-      for(i = 0; i < NumCalls; i++) {
-         if(STRCMP(Calls[i],pCC->Callsign) == 0) {
-            CallFound[i] = TRUE;
-            bDoIt = TRUE;
-            bByCall = TRUE;
-            CallsFound++;
-            break;
-         }
-      }
+    }
 
-      if(bDoIt) {
-         bDidit = TRUE;
-         if(bMuteChat) {
-            pCC->bMuteChat = bMute;
-         }
-         else {
-            pCC->bMuted = bMute;
-         }
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+    if ((!pCC->bSysop || bDoSyops || !bMute) && (pCC != pCC1 || !bMute) &&
+        (pCC != ClientTalking || bDoTalker) &&
+        ((bDoTBD && pCC->bTBD) || (bDoConf && pCC->bConf && !pCC->bTBD) ||
+         (bDoUsers && !(pCC->bLink || pCC->bRepeater || pCC->bConf)) ||
+         (bDoSyops && pCC->bSysop) ||
+         (bDoRF && (pCC->bLink || pCC->bRepeater)) ||
+         (bDoTalker && pCC == ClientTalking))) {
+      bDoIt = TRUE;
+    }
 
-   if(NumCalls > 0 && bPersistent) {
-   // Persistent request
-      for(i = 0; i < NumCalls; i++) {
-         UserLookup.Callsign = Calls[i];
-         if((pUser = avl_find(UserTree,&UserLookup)) != NULL) {
-         // user is in directory, save his mute flag
-            if(bMuteChat) {
-               pUser->bChatMuted = bMute;
-               pUser->bChatUnMuted = !bMute;
-            }
-            else {
-               pUser->bMuted = bMute;
-               pUser->bUnMuted = !bMute;
-            }
-         }
-         else {
-            LOG_WARN(("CmdMuteCommon(): %s not in directory.\n",
-                      pCC->Callsign));
-         }
+    for (i = 0; i < NumCalls; i++) {
+      if (STRCMP(Calls[i], pCC->Callsign) == 0) {
+        CallFound[i] = TRUE;
+        bDoIt = TRUE;
+        bByCall = TRUE;
+        CallsFound++;
+        break;
       }
-   }
+    }
 
-   if(bDoUsage) {
-      Rcode = TBD_ERR_INVALID_CMD;
-      if(bMute) {
-         BufPrintf(p,"Usage: mute -[aceprstuX] [<call> ...] [.] [chat]\r");
+    if (bDoIt) {
+      bDidit = TRUE;
+      if (bMuteChat) {
+        pCC->bMuteChat = bMute;
+      } else {
+        pCC->bMuted = bMute;
       }
-      else {
-         BufPrintf(p,"Usage: unmute -[aceprsuX] [<call> ...] [chat]\r");
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+
+  if (NumCalls > 0 && bPersistent) {
+    // Persistent request
+    for (i = 0; i < NumCalls; i++) {
+      UserLookup.Callsign = Calls[i];
+      if ((pUser = avl_find(UserTree, &UserLookup)) != NULL) {
+        // user is in directory, save his mute flag
+        if (bMuteChat) {
+          pUser->bChatMuted = bMute;
+          pUser->bChatUnMuted = !bMute;
+        } else {
+          pUser->bMuted = bMute;
+          pUser->bUnMuted = !bMute;
+        }
+      } else {
+        LOG_WARN(("CmdMuteCommon(): %s not in directory.\n", pCC->Callsign));
       }
-      BufPrintf(p,
-                "  -a: All users\r"
-                "  -c: tbd conferences\r"
-                "  -e: Echolink conferences\r"
-                "  -p: Persistent\r"
-                "  -r: RF users (-R and -L stations)\r"
-                "  -s: Sysops and Admins\r"
-                "  -t: Station talking\r"
-                "  -u: PC users\r"
-                "  -x: chat text from user\r"
-                "<call>: specific user\r");
-   }
-   else if(!bDidit && bDoTalker && OptionsFound == 1 && ClientTalking == NULL) {
-   // Simple attempt to mute current talker and no one is talking.
-      Rcode = TBD_ERR_NO_TALKER;
-      if(!pCC1->bConf) {
+    }
+  }
+
+  if (bDoUsage) {
+    Rcode = TBD_ERR_INVALID_CMD;
+    if (bMute) {
+      BufPrintf(p, "Usage: mute -[aceprstuX] [<call> ...] [.] [chat]\r");
+    } else {
+      BufPrintf(p, "Usage: unmute -[aceprsuX] [<call> ...] [chat]\r");
+    }
+    BufPrintf(p, "  -a: All users\r"
+                 "  -c: tbd conferences\r"
+                 "  -e: Echolink conferences\r"
+                 "  -p: Persistent\r"
+                 "  -r: RF users (-R and -L stations)\r"
+                 "  -s: Sysops and Admins\r"
+                 "  -t: Station talking\r"
+                 "  -u: PC users\r"
+                 "  -x: chat text from user\r"
+                 "<call>: specific user\r");
+  } else if (!bDidit && bDoTalker && OptionsFound == 1 &&
+             ClientTalking == NULL) {
+    // Simple attempt to mute current talker and no one is talking.
+    Rcode = TBD_ERR_NO_TALKER;
+    if (!pCC1->bConf) {
       // Command received from a local sysop, not via a quoted command
       // Forward the command
-         BufPrintf(p,"Error: no one is talking.\r");
+      BufPrintf(p, "Error: no one is talking.\r");
+    }
+  } else if (bDoList) {
+    // Now list persistently muted/unmuted text
+    pUser = (UserInfo *)avl_t_first(&avl_trans, UserTree);
+    while (pUser != NULL) {
+      if ((bMute && pUser->bChatMuted) || (!bMute && pUser->bChatUnMuted)) {
+        if (PersistentCalls++ == 0) {
+          BufPrintf(p, "Stations with persistently %s text:\r",
+                    bMute ? "muted" : "unmuted");
+        }
+        BufPrintf(p, "%s\r", pUser->Callsign);
       }
-   }
-   else if(bDoList) {
-   // Now list persistently muted/unmuted text
-      pUser = (UserInfo *) avl_t_first(&avl_trans,UserTree);
-      while(pUser != NULL) {
-         if((bMute && pUser->bChatMuted) || (!bMute && pUser->bChatUnMuted)) {
-            if(PersistentCalls++ == 0) {
-               BufPrintf(p,"Stations with persistently %s text:\r",
-                         bMute ? "muted" : "unmuted");
-            }
-            BufPrintf(p,"%s\r",pUser->Callsign);
-         }
-         pUser = (UserInfo *) avl_t_next(&avl_trans);
+      pUser = (UserInfo *)avl_t_next(&avl_trans);
+    }
+
+    // Now list persistently muted/unmuted stations
+    PersistentCalls = 0;
+    pUser = (UserInfo *)avl_t_first(&avl_trans, UserTree);
+    while (pUser != NULL) {
+      if ((bMute && pUser->bMuted) || (!bMute && pUser->bUnMuted)) {
+        if (PersistentCalls++ == 0) {
+          BufPrintf(p, "Stations persistently %s:\r",
+                    bMute ? "muted" : "unmuted");
+        }
+        BufPrintf(p, "%s\r", pUser->Callsign);
       }
-   
-   // Now list persistently muted/unmuted stations
-      PersistentCalls = 0;
-      pUser = (UserInfo *) avl_t_first(&avl_trans,UserTree);
-      while(pUser != NULL) {
-         if((bMute && pUser->bMuted) || (!bMute && pUser->bUnMuted)) {
-            if(PersistentCalls++ == 0) {
-               BufPrintf(p,"Stations persistently %s:\r",
-                         bMute ? "muted" : "unmuted");
-            }
-            BufPrintf(p,"%s\r",pUser->Callsign);
-         }
-         pUser = (UserInfo *) avl_t_next(&avl_trans);
+      pUser = (UserInfo *)avl_t_next(&avl_trans);
+    }
+
+    if (!bDidit) {
+      BufPrintf(p, "No stations are currently muted.\r", Arg);
+    }
+
+    if (PersistentCalls == 0 && !bMute) {
+      BufPrintf(p, "No stations are unmuted persistently.\r", Arg);
+    }
+
+    if (pCS->bMuteConf || pCS->bMuteUsers || pCS->bMuteRF || pCS->bMuteTBD) {
+      BufPrintf(p, "New connections from ");
+      SetSep = " and ";
+      if (pCS->bMuteConf) {
+        BufPrintf(p, "Echolink conferences");
+        Sep = SetSep;
       }
 
-      if(!bDidit) {
-         BufPrintf(p,"No stations are currently muted.\r",Arg);
+      if (pCS->bMuteTBD) {
+        BufPrintf(p, "%stbd conferences", Sep);
+        Sep = SetSep;
       }
 
-      if(PersistentCalls == 0 && !bMute) {
-         BufPrintf(p,"No stations are unmuted persistently.\r",Arg);
+      if (pCS->bMuteUsers) {
+        BufPrintf(p, "%sPC users", Sep);
+        Sep = SetSep;
       }
 
-      if(pCS->bMuteConf || pCS->bMuteUsers || pCS->bMuteRF || pCS->bMuteTBD) {
-         BufPrintf(p,"New connections from ");
-         SetSep = " and ";
-         if(pCS->bMuteConf) {
-            BufPrintf(p,"Echolink conferences");
-            Sep = SetSep;
-         }
-
-         if(pCS->bMuteTBD) {
-            BufPrintf(p,"%stbd conferences",Sep);
-            Sep = SetSep;
-         }
-
-         if(pCS->bMuteUsers) {
-            BufPrintf(p,"%sPC users",Sep);
-            Sep = SetSep;
-         }
-
-         if(pCS->bMuteRF) {
-            BufPrintf(p,"%sRF users",Sep);
-            Sep = SetSep;
-         }
-         BufPrintf(p," will be muted.\r");
+      if (pCS->bMuteRF) {
+        BufPrintf(p, "%sRF users", Sep);
+        Sep = SetSep;
       }
+      BufPrintf(p, " will be muted.\r");
+    }
 
-      if(pCS->bMuteChat) {
-         BufPrintf(p,"Chat text from new connections will be muted.\r");
-      }
+    if (pCS->bMuteChat) {
+      BufPrintf(p, "Chat text from new connections will be muted.\r");
+    }
 
-      if(pCC1->bNoChat) {
-         BufPrintf(p,"Your text chat is muted.\r");
-      }
-   }
-   else {
-      if(bDidit) {
-       // Did something
-         SetSep = ", ";
-      }
-      else {
+    if (pCC1->bNoChat) {
+      BufPrintf(p, "Your text chat is muted.\r");
+    }
+  } else {
+    if (bDidit) {
+      // Did something
+      SetSep = ", ";
+    } else {
       // Didn't do anything
-         BufPrintf(p,"No ");
-         SetSep = " or ";
-      }
+      BufPrintf(p, "No ");
+      SetSep = " or ";
+    }
 
-      if(bDoConf) {
-         BufPrintf(p,"EchoLink conferences");
-         Sep = SetSep;
-      }
+    if (bDoConf) {
+      BufPrintf(p, "EchoLink conferences");
+      Sep = SetSep;
+    }
 
-      if(bDoTBD) {
-         BufPrintf(p,"%stbd conferences",Sep);
-         Sep = SetSep;
-      }
+    if (bDoTBD) {
+      BufPrintf(p, "%stbd conferences", Sep);
+      Sep = SetSep;
+    }
 
-      if(bDoUsers) {
-         BufPrintf(p,"%sPC users",Sep);
-         Sep = SetSep;
-      }
+    if (bDoUsers) {
+      BufPrintf(p, "%sPC users", Sep);
+      Sep = SetSep;
+    }
 
-      if(bDoSyops) {
-         BufPrintf(p,"%ssysops",Sep);
-         Sep = SetSep;
-      }
-      
-      if(bDoRF) {
-         BufPrintf(p,"%sRF users",Sep);
-         Sep = SetSep;
-      }
+    if (bDoSyops) {
+      BufPrintf(p, "%ssysops", Sep);
+      Sep = SetSep;
+    }
 
-      if(bDoTalker && (bDidTalker || !bDidit)) {
-         BufPrintf(p,"%sstation talking",Sep);
-         Sep = SetSep;
-      }
+    if (bDoRF) {
+      BufPrintf(p, "%sRF users", Sep);
+      Sep = SetSep;
+    }
 
-      if(bDidChat) {
-         BufPrintf(p,"%schat text",Sep);
-         Sep = SetSep;
-      }
+    if (bDoTalker && (bDidTalker || !bDidit)) {
+      BufPrintf(p, "%sstation talking", Sep);
+      Sep = SetSep;
+    }
 
-      for(i = 0; i < NumCalls; i++) {
-         if((bDidit && CallFound[i]) || (!bDidit && !CallFound[i])) {
-            BufPrintf(p,"%s%s",Sep,Calls[i]);
-            Sep = SetSep;
-         }
-      }
+    if (bDidChat) {
+      BufPrintf(p, "%schat text", Sep);
+      Sep = SetSep;
+    }
 
-      if(bDidit) {
-         BufPrintf(p,"%s%s%s",
-                   bMuteChat ? " text" : "",
-                   bPersistent ? " persistently" : "",
-                   bMute ? " muted" : " unmuted");
-         LOG_NORM(("%s by %s\n",MsgStart,pCC1->Callsign));
-         BufPrintf(p,".\r");
+    for (i = 0; i < NumCalls; i++) {
+      if ((bDidit && CallFound[i]) || (!bDidit && !CallFound[i])) {
+        BufPrintf(p, "%s%s", Sep, Calls[i]);
+        Sep = SetSep;
+      }
+    }
 
-         if(NumCalls != CallsFound) {
-            Sep = "";
-            for(i = 0; i < NumCalls; i++) {
-               if(!CallFound[i]) {
-                  BufPrintf(p,"%s%s",Sep,Calls[i]);
-                  Sep = ", ";
-               }
-            }
-            BufPrintf(p," not found.\r");
-            Rcode = TBD_STATION_NOT_FOUND;
-         }
+    if (bDidit) {
+      BufPrintf(p, "%s%s%s", bMuteChat ? " text" : "",
+                bPersistent ? " persistently" : "",
+                bMute ? " muted" : " unmuted");
+      LOG_NORM(("%s by %s\n", MsgStart, pCC1->Callsign));
+      BufPrintf(p, ".\r");
+
+      if (NumCalls != CallsFound) {
+        Sep = "";
+        for (i = 0; i < NumCalls; i++) {
+          if (!CallFound[i]) {
+            BufPrintf(p, "%s%s", Sep, Calls[i]);
+            Sep = ", ";
+          }
+        }
+        BufPrintf(p, " not found.\r");
+        Rcode = TBD_STATION_NOT_FOUND;
       }
-      else {
-         BufPrintf(p," found.\r");
-         Rcode = TBD_STATION_NOT_FOUND;
-      }
-   }
-   #undef MAX_MUTE_CALLS
+    } else {
+      BufPrintf(p, " found.\r");
+      Rcode = TBD_STATION_NOT_FOUND;
+    }
+  }
+#undef MAX_MUTE_CALLS
 }
 
-void CmdUnMute(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   CmdMuteCommon(p,pCC1,Arg,FALSE);
+void CmdUnMute(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  CmdMuteCommon(p, pCC1, Arg, FALSE);
 }
 
-void CmdMute(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   CmdMuteCommon(p,pCC1,Arg,TRUE);
+void CmdMute(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  CmdMuteCommon(p, pCC1, Arg, TRUE);
 }
 
-void StopRecording(ClientInfo *p,const char *Arg)
-{
-   FilePacketHdr PktHdr;
-   ConfServer *pCS = ((ConfServer *) p->p)->pMasterCS;
+void StopRecording(ClientInfo *p, const char *Arg) {
+  FilePacketHdr PktHdr;
+  ConfServer *pCS = ((ConfServer *)p->p)->pMasterCS;
 
-   if(pCS->fp != NULL) {
-   // Write end of stream record
-      PktHdr.Len = 0;
-      PktHdr.Flags = 0;
+  if (pCS->fp != NULL) {
+    // Write end of stream record
+    PktHdr.Len = 0;
+    PktHdr.Flags = 0;
 
-      if(fwrite(&PktHdr,sizeof(PktHdr),1,pCS->fp) != 1) {
+    if (fwrite(&PktHdr, sizeof(PktHdr), 1, pCS->fp) != 1) {
       // Write error
-         LOG_ERROR(("StopRecording(): fwrite failed, %s",Err2String(errno)));
-      }
+      LOG_ERROR(("StopRecording(): fwrite failed, %s", Err2String(errno)));
+    }
 
-      fclose(pCS->fp);
-      pCS->fp = NULL;
-      pCS->bRecording = FALSE;
-      BufPrintf(p,"Recording completed.\r");
-   }
-   else if(STRCMP(Arg,"stop") == 0) {
-      BufPrintf(p,"Can't stop, we're not recording.\r");
-   }
+    fclose(pCS->fp);
+    pCS->fp = NULL;
+    pCS->bRecording = FALSE;
+    BufPrintf(p, "Recording completed.\r");
+  } else if (STRCMP(Arg, "stop") == 0) {
+    BufPrintf(p, "Can't stop, we're not recording.\r");
+  }
 }
 
 // Arg = filename
-void CmdRecord(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   char *cp;
-   ConfServer *pCS = ((ConfServer *) p->p)->pMasterCS;
-   
-   StopRecording(p,Arg);
+void CmdRecord(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  char *cp;
+  ConfServer *pCS = ((ConfServer *)p->p)->pMasterCS;
 
-// Point Arg to the a bare filename to prevent "accidents"
-   if((cp = strrchr(Arg,'\\')) != NULL) {
-      Arg = cp + 1;
-   }
+  StopRecording(p, Arg);
 
-   if((cp = strrchr(Arg,'/')) != NULL) {
-      Arg = cp + 1;
-   }
+  // Point Arg to the a bare filename to prevent "accidents"
+  if ((cp = strrchr(Arg, '\\')) != NULL) {
+    Arg = cp + 1;
+  }
 
-   if(STRCMP(Arg,"stop") != 0) {
-      if((pCS->fp = FOPEN(Arg,MODE_RDWR_BIN)) == NULL) {
-         pCS->bRecording = FALSE;
-         BufPrintf(p,"Error: Couldn't open %s.",Arg);
-         Rcode = TBD_ERR_FILE_OPEN;
-      }
-      else {
-         pCS->bRecording = TRUE;
-         BufPrintf(p,"Recording to %s.\r",Arg);
-      }
-   }
+  if ((cp = strrchr(Arg, '/')) != NULL) {
+    Arg = cp + 1;
+  }
+
+  if (STRCMP(Arg, "stop") != 0) {
+    if ((pCS->fp = FOPEN(Arg, MODE_RDWR_BIN)) == NULL) {
+      pCS->bRecording = FALSE;
+      BufPrintf(p, "Error: Couldn't open %s.", Arg);
+      Rcode = TBD_ERR_FILE_OPEN;
+    } else {
+      pCS->bRecording = TRUE;
+      BufPrintf(p, "Recording to %s.\r", Arg);
+    }
+  }
 }
 
-void CmdRefresh(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   NextStationListTime = TimeNow.tv_sec + StationListInterval;
-   ServerRequest(SERV_REQ_LOGIN_AND_LIST,0,NULL);
+void CmdRefresh(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  NextStationListTime = TimeNow.tv_sec + StationListInterval;
+  ServerRequest(SERV_REQ_LOGIN_AND_LIST, 0, NULL);
 }
 
-void CmdRehash(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   bRefreshConfig = TRUE;
-   BufPrintf(p,"Reloading configuration file.\r");
+void CmdRehash(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  bRefreshConfig = TRUE;
+  BufPrintf(p, "Reloading configuration file.\r");
 }
 
-void CmdSet(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   struct config_entry *pVars = ConfigVars;
-   char *cp;
-   int x;
-   float f;
-   int bSetVariable = FALSE;
-   void *var_ptr;
-   char Line[80];
-   int bFirstLoop = TRUE;
-   int Err;
+void CmdSet(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  struct config_entry *pVars = ConfigVars;
+  char *cp;
+  int x;
+  float f;
+  int bSetVariable = FALSE;
+  void *var_ptr;
+  char Line[80];
+  int bFirstLoop = TRUE;
+  int Err;
 
-   do {
-      if(*Arg == 0) {
-         Rcode = TBD_ERR_INVALID_CMD;
-         BufPrintf(p,"Usage:\n");
-         BufPrintf(p,"set variable\r");
-         BufPrintf(p,"set variable = value\r");
-         break;
-      }
-
-      if(strchr(Arg,'=') != NULL) {
-         Err = ParseConfigLine(Arg,pVars,MANUAL_SET);
-#ifdef   LINK_BOX
-         if(Err != 0 && (pVars = GetConfigVarsPtr()) != ConfigVars) {
-         // Try again
-            Err = ParseConfigLine(Arg,pVars,MANUAL_SET);
-            bFirstLoop = FALSE;
-         }
-#endif
-         if(Err != 0) {
-            Rcode = TBD_ERR_INVALID_ARG;
-            BufPrintf(p,"Error: Unable to set variable.\r");
-            break;
-         }
-         else {
-            bSetVariable = TRUE;
-         }
-      }
-
-      if(Rcode == TBD_OK) {
-      // display the current value
-         if((cp = strchr(Arg,' ')) != NULL) {
-         // Remove trailing spaces
-            *cp = 0;
-         }
-         if((cp = strchr(Arg,'=')) != NULL) {
-         // Remove '='
-            *cp = 0;
-         }
-
-         while(pVars->var_name[0] != 0) {
-            if(!STRCMP(Arg,pVars->var_name)) {
-            // found our guy
-               if(pVars->Flags & CON_FLG_BASED_VAR) {
-                  if((var_ptr = ConfigGetVarPtr(pVars)) == NULL) {
-                     BufPrintf(p,"Error: Unable to set variable.\r");
-                     break;
-                  }
-               }
-               else {
-                  var_ptr = pVars->var_ptr;
-               }
-
-               switch(pVars->var_type[1]) {
-                  case 's':   // String value
-                  // string value, make sure it's set
-                     cp = *((char **) var_ptr);
-                     if(cp == NULL) {
-                        BufPrintf(p,"variable %s is not set\r",pVars->var_name);
-                     }
-                     else {
-                        BufPrintf(p,"%s = \"%s\"\r",pVars->var_name,cp);
-                     }
-                     break;
-
-                  case 'd':   // int
-                  case 'x':
-                     x = *((int *) var_ptr);
-                     BufPrintf(p,"%s = ",pVars->var_name);
-                     BufPrintf(p,pVars->var_type,x);
-                     BufPrintf(p,"\r");
-                     break;
-
-                  case 'f':   // float
-                     f = *((float *) var_ptr);
-                     BufPrintf(p,"%s = ",pVars->var_name);
-                     BufPrintf(p,pVars->var_type,f);
-                     BufPrintf(p,"\r");
-                     break;
-
-                  case 'F':
-                  // value is set via function call.
-                     Line[0] = 0;
-                     pVars->AccessFunc(pVars,Line,AF_DISPLAY_VAR,sizeof(Line));
-                     if(Line[0] == 0) {
-
-                        BufPrintf(p,"Sorry, variable %s can not be displayed\r",
-                                  pVars->var_name);
-                     }
-                     else {
-                        BufPrintf(p,"%s = %s\r",pVars->var_name,Line);
-                     }
-                     break;
-
-                  default:
-                     if(!bSetVariable) {
-                        BufPrintf(p,"Sorry, variable %s can not be displayed\r",
-                                  pVars->var_name);
-                     }
-                     break;
-               }
-               break;
-            }
-            pVars++;
-         }
-
-         if(pVars->var_name[0] != 0) {
-         // Found it 
-            break;
-         }
-
-#ifdef   LINK_BOX
-         if((pVars = GetConfigVarsPtr()) == ConfigVars) 
-#endif
-            bFirstLoop = FALSE;
-
-         if(!bFirstLoop) {
-            BufPrintf(p,"variable %s not found\r",Arg);
-            Rcode = TBD_ERR_INVALID_ARG;
-            break;
-         }
-         bFirstLoop = FALSE;
-      }
-   } while(TRUE);
-}
-
-void CmdShowIP(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   ConfClient *pCC;
-   char TypeChar;
-
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      switch(pCC->Proto) {
-         case PROTO_SF:
-            TypeChar = 'S';
-            break;
-
-         case PROTO_RTP:
-            TypeChar = 'R';
-            break;
-
-         case PROTO_ILINK:
-            TypeChar = 'E';
-            break;
-
-         default:
-            TypeChar = '?';
-            break;
-      }
-      BufPrintf(p,"%s\t%s\t%c\r",pCC->Callsign,
-                inet_ntoa(pCC->HisAdr.i.sin_addr),TypeChar);
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-   BufPrintf(p,"\r");
-}
-
-void CmdDNS(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   if(STRCMP(Arg,"refresh") == 0) {
-      UpdateDNSCache(TRUE);
-      BufPrintf(p,"Refreshing DNS cache\r");
-   }
-   else if(STRCMP(Arg,"list") == 0) {
-      DumpDNSCache(p);
-   }
-   else {
-      BufPrintf(p,"Usage:\r"
-                  "dns refresh\r"
-                  "dns list\r");
+  do {
+    if (*Arg == 0) {
       Rcode = TBD_ERR_INVALID_CMD;
-   }
+      BufPrintf(p, "Usage:\n");
+      BufPrintf(p, "set variable\r");
+      BufPrintf(p, "set variable = value\r");
+      break;
+    }
+
+    if (strchr(Arg, '=') != NULL) {
+      Err = ParseConfigLine(Arg, pVars, MANUAL_SET);
+#ifdef LINK_BOX
+      if (Err != 0 && (pVars = GetConfigVarsPtr()) != ConfigVars) {
+        // Try again
+        Err = ParseConfigLine(Arg, pVars, MANUAL_SET);
+        bFirstLoop = FALSE;
+      }
+#endif
+      if (Err != 0) {
+        Rcode = TBD_ERR_INVALID_ARG;
+        BufPrintf(p, "Error: Unable to set variable.\r");
+        break;
+      } else {
+        bSetVariable = TRUE;
+      }
+    }
+
+    if (Rcode == TBD_OK) {
+      // display the current value
+      if ((cp = strchr(Arg, ' ')) != NULL) {
+        // Remove trailing spaces
+        *cp = 0;
+      }
+      if ((cp = strchr(Arg, '=')) != NULL) {
+        // Remove '='
+        *cp = 0;
+      }
+
+      while (pVars->var_name[0] != 0) {
+        if (!STRCMP(Arg, pVars->var_name)) {
+          // found our guy
+          if (pVars->Flags & CON_FLG_BASED_VAR) {
+            if ((var_ptr = ConfigGetVarPtr(pVars)) == NULL) {
+              BufPrintf(p, "Error: Unable to set variable.\r");
+              break;
+            }
+          } else {
+            var_ptr = pVars->var_ptr;
+          }
+
+          switch (pVars->var_type[1]) {
+          case 's': // String value
+                    // string value, make sure it's set
+            cp = *((char **)var_ptr);
+            if (cp == NULL) {
+              BufPrintf(p, "variable %s is not set\r", pVars->var_name);
+            } else {
+              BufPrintf(p, "%s = \"%s\"\r", pVars->var_name, cp);
+            }
+            break;
+
+          case 'd': // int
+          case 'x':
+            x = *((int *)var_ptr);
+            BufPrintf(p, "%s = ", pVars->var_name);
+            BufPrintf(p, pVars->var_type, x);
+            BufPrintf(p, "\r");
+            break;
+
+          case 'f': // float
+            f = *((float *)var_ptr);
+            BufPrintf(p, "%s = ", pVars->var_name);
+            BufPrintf(p, pVars->var_type, f);
+            BufPrintf(p, "\r");
+            break;
+
+          case 'F':
+            // value is set via function call.
+            Line[0] = 0;
+            pVars->AccessFunc(pVars, Line, AF_DISPLAY_VAR, sizeof(Line));
+            if (Line[0] == 0) {
+
+              BufPrintf(p, "Sorry, variable %s can not be displayed\r",
+                        pVars->var_name);
+            } else {
+              BufPrintf(p, "%s = %s\r", pVars->var_name, Line);
+            }
+            break;
+
+          default:
+            if (!bSetVariable) {
+              BufPrintf(p, "Sorry, variable %s can not be displayed\r",
+                        pVars->var_name);
+            }
+            break;
+          }
+          break;
+        }
+        pVars++;
+      }
+
+      if (pVars->var_name[0] != 0) {
+        // Found it
+        break;
+      }
+
+#ifdef LINK_BOX
+      if ((pVars = GetConfigVarsPtr()) == ConfigVars)
+#endif
+        bFirstLoop = FALSE;
+
+      if (!bFirstLoop) {
+        BufPrintf(p, "variable %s not found\r", Arg);
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      }
+      bFirstLoop = FALSE;
+    }
+  } while (TRUE);
 }
 
-void CmdKick(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
+void CmdShowIP(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  ConfClient *pCC;
+  char TypeChar;
 
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    switch (pCC->Proto) {
+    case PROTO_SF:
+      TypeChar = 'S';
+      break;
 
-      if(STRCMP(Arg,pCC->Callsign) == 0) {
-         LOG_NORM(("%s kicked by %s\n",pCC->Callsign,pCC1->Callsign));
-         BufPrintf(p,"%s kicked\r",Arg);
-         pCC->bKicked = TRUE;
-         if(pCC->bConnected) {
-            pCC->bConnected = FALSE;
-            ConferenceClients--;
-         }
-         pCC->bSWL = TRUE;
-         break;
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+    case PROTO_RTP:
+      TypeChar = 'R';
+      break;
 
-   if(pCC == NULL) {
-      BufPrintf(p,"%s not found\r",Arg);
-      Rcode = TBD_STATION_NOT_FOUND;
-   }
+    case PROTO_ILINK:
+      TypeChar = 'E';
+      break;
+
+    default:
+      TypeChar = '?';
+      break;
+    }
+    BufPrintf(p, "%s\t%s\t%c\r", pCC->Callsign,
+              inet_ntoa(pCC->HisAdr.i.sin_addr), TypeChar);
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+  BufPrintf(p, "\r");
 }
 
-void ACLAdd(ClientInfo *p,ConfClient *pCC1,char *Arg,int bAllowed)
-{
-   ACL_User ACL_New;
-   char *CmdString = bAllowed ? "allowed" : "banned";
-   char  *WhiteSpace = "\t\n ";
-   int Count = p->Count;
+void CmdDNS(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  if (STRCMP(Arg, "refresh") == 0) {
+    UpdateDNSCache(TRUE);
+    BufPrintf(p, "Refreshing DNS cache\r");
+  } else if (STRCMP(Arg, "list") == 0) {
+    DumpDNSCache(p);
+  } else {
+    BufPrintf(p, "Usage:\r"
+                 "dns refresh\r"
+                 "dns list\r");
+    Rcode = TBD_ERR_INVALID_CMD;
+  }
+}
 
-   if(!bAllowed) {
-   // Kick the guy if he's on currently
-      CmdKick(p,pCC1,Arg);
-      p->Count = Count; // remove message generated by kick command
-   }
+void CmdKick(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
 
-   memset(&ACL_New,0,sizeof(ACL_New));
-   ACL_New.bAuthorized = bAllowed;
-   
-   ACL_New.Callsign = strtok(Arg,WhiteSpace);
-   Convert2Upper(ACL_New.Callsign);
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
 
-   ACL_New.HostName = strtok(NULL,WhiteSpace);
-
-   if(ACL_New.HostName == NULL) {
-      ACL_New.HostName = "-";
-   }
-   else {
-      ACL_New.Password = strtok(NULL,WhiteSpace);
-   }
-
-   if(ACL_New.Password == NULL) {
-      ACL_New.Password = "-";
-   }
-   else {
-      // Take the rest of the string
-      ACL_New.CallPlus = strtok(NULL,"");
-      if(ACL_New.CallPlus != NULL) {
-         // Skip leading white space
-         while(*ACL_New.CallPlus && isspace(*ACL_New.CallPlus)) {
-            ACL_New.CallPlus++;
-         }
+    if (STRCMP(Arg, pCC->Callsign) == 0) {
+      LOG_NORM(("%s kicked by %s\n", pCC->Callsign, pCC1->Callsign));
+      BufPrintf(p, "%s kicked\r", Arg);
+      pCC->bKicked = TRUE;
+      if (pCC->bConnected) {
+        pCC->bConnected = FALSE;
+        ConferenceClients--;
       }
-   }
+      pCC->bSWL = TRUE;
+      break;
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-   if(!ACLAddUser(&ACL_New)) {
-      BufPrintf(p,"Error unable to resolve hostname \"%s\".",
-                ACL_New.HostName);
-   }
-   else {
+  if (pCC == NULL) {
+    BufPrintf(p, "%s not found\r", Arg);
+    Rcode = TBD_STATION_NOT_FOUND;
+  }
+}
+
+void ACLAdd(ClientInfo *p, ConfClient *pCC1, char *Arg, int bAllowed) {
+  ACL_User ACL_New;
+  char *CmdString = bAllowed ? "allowed" : "banned";
+  char *WhiteSpace = "\t\n ";
+  int Count = p->Count;
+
+  if (!bAllowed) {
+    // Kick the guy if he's on currently
+    CmdKick(p, pCC1, Arg);
+    p->Count = Count; // remove message generated by kick command
+  }
+
+  memset(&ACL_New, 0, sizeof(ACL_New));
+  ACL_New.bAuthorized = bAllowed;
+
+  ACL_New.Callsign = strtok(Arg, WhiteSpace);
+  Convert2Upper(ACL_New.Callsign);
+
+  ACL_New.HostName = strtok(NULL, WhiteSpace);
+
+  if (ACL_New.HostName == NULL) {
+    ACL_New.HostName = "-";
+  } else {
+    ACL_New.Password = strtok(NULL, WhiteSpace);
+  }
+
+  if (ACL_New.Password == NULL) {
+    ACL_New.Password = "-";
+  } else {
+    // Take the rest of the string
+    ACL_New.CallPlus = strtok(NULL, "");
+    if (ACL_New.CallPlus != NULL) {
+      // Skip leading white space
+      while (*ACL_New.CallPlus && isspace(*ACL_New.CallPlus)) {
+        ACL_New.CallPlus++;
+      }
+    }
+  }
+
+  if (!ACLAddUser(&ACL_New)) {
+    BufPrintf(p, "Error unable to resolve hostname \"%s\".", ACL_New.HostName);
+  } else {
+    SaveACL();
+    BufPrintf(p, "%s %s\r", Arg, CmdString);
+    LOG_NORM(("%s %s by %s\n", ACL_New.Callsign, CmdString, pCC1->Callsign));
+  }
+}
+
+void ACLDelete(ClientInfo *p, ConfClient *pCC1, char *Arg, int bAllowed) {
+  ACL_User *pACL = NULL;
+  ACL_User ACL_Lookup;
+  char *cp;
+  char *CmdString = bAllowed ? "allowed" : "banned";
+
+  // Remove possible -L or -R from the argument, we ban the base call
+
+  if ((cp = strchr(Arg, '-')) != NULL) {
+    *cp = 0;
+  }
+
+  ACL_Lookup.Callsign = Arg;
+  Convert2Upper(ACL_Lookup.Callsign);
+
+  if ((pACL = avl_find(ACL_Call_Tree, &ACL_Lookup)) != NULL) {
+    if ((bAllowed && pACL->bAuthorized) || (!bAllowed && !pACL->bAuthorized)) {
+      DeleteACLUser(pACL);
+      BufPrintf(p, "%s removed from the %s list.\r", Arg, CmdString);
       SaveACL();
-      BufPrintf(p,"%s %s\r",Arg,CmdString);
-      LOG_NORM(("%s %s by %s\n",ACL_New.Callsign,CmdString,pCC1->Callsign));
-   }
+    } else {
+      pACL = NULL;
+    }
+  }
+
+  if (pACL == NULL) {
+    BufPrintf(p, "%s was not found on the %s list.\r", Arg, CmdString);
+  }
 }
 
-void ACLDelete(ClientInfo *p,ConfClient *pCC1,char *Arg,int bAllowed)
-{
-   ACL_User *pACL = NULL;
-   ACL_User ACL_Lookup;
-   char *cp;
-   char *CmdString = bAllowed ? "allowed" : "banned";
+void ACLList(ClientInfo *p, ConfClient *pCC1, const char *Arg, int bAllowed) {
+  ACL_User *pACL = NULL;
+  struct avl_traverser avl_trans;
+  int Count = 0;
+  char *CmdString = bAllowed ? "allowed" : "banned";
+  ACL_User *pNextACL;
 
-// Remove possible -L or -R from the argument, we ban the base call
-
-   if((cp = strchr(Arg,'-')) != NULL) {
-      *cp = 0;
-   }
-
-   ACL_Lookup.Callsign = Arg;
-   Convert2Upper(ACL_Lookup.Callsign);
-
-   if((pACL = avl_find(ACL_Call_Tree,&ACL_Lookup)) != NULL) {
-      if((bAllowed && pACL->bAuthorized) || (!bAllowed && !pACL->bAuthorized)) {
-         DeleteACLUser(pACL);
-         BufPrintf(p,"%s removed from the %s list.\r",Arg,CmdString);
-         SaveACL();
+  pNextACL = (ACL_User *)avl_t_first(&avl_trans, ACL_Call_Tree);
+  while ((pACL = pNextACL) != NULL) {
+    // NB: Get the next user now in case we deleted the current user
+    pNextACL = (ACL_User *)avl_t_next(&avl_trans);
+    if ((bAllowed && pACL->bAuthorized) || (!bAllowed && !pACL->bAuthorized)) {
+      if (Count++ == 0) {
+        BufPrintf(p, "%s users:\r", CmdString);
       }
-      else {
-         pACL = NULL;
-      }
-   }
-   
-   if(pACL == NULL) {
-      BufPrintf(p,"%s was not found on the %s list.\r",Arg,CmdString);
-   }
-}
+      BufPrintf(p, "%s %s\r", pACL->CallPlus, pACL->HostName);
+    }
+  }
 
-void ACLList(ClientInfo *p,ConfClient *pCC1,const char *Arg,int bAllowed)
-{
-   ACL_User *pACL = NULL;
-   struct avl_traverser avl_trans;
-   int Count = 0;
-   char *CmdString = bAllowed ? "allowed" : "banned";
-   ACL_User *pNextACL;
-
-   pNextACL = (ACL_User *) avl_t_first(&avl_trans,ACL_Call_Tree);
-   while((pACL = pNextACL) != NULL) {
-   // NB: Get the next user now in case we deleted the current user
-      pNextACL = (ACL_User *) avl_t_next(&avl_trans);
-      if((bAllowed && pACL->bAuthorized) || (!bAllowed && !pACL->bAuthorized)) {
-         if(Count++ == 0) {
-            BufPrintf(p,"%s users:\r",CmdString);
-         }
-         BufPrintf(p,"%s %s\r",pACL->CallPlus,pACL->HostName);
-      }
-   }
-   
-   if(Count == 0) {
-      BufPrintf(p,"The %s list is empty.\r",CmdString);
-   }
+  if (Count == 0) {
+    BufPrintf(p, "The %s list is empty.\r", CmdString);
+  }
 }
 
 // [allow | deny] add <callsign> [<hostname> [<user name>]]
-void CmdACL(ClientInfo *p,ConfClient *pCC1,char *Arg,int bAllowed)
-{
-   char *cp;
+void CmdACL(ClientInfo *p, ConfClient *pCC1, char *Arg, int bAllowed) {
+  char *cp;
 
-   if((cp = strchr(Arg,' ')) != NULL) {
-      *cp++ = 0;
-      while(*cp && *cp == ' ') {
-         cp++;
-      }
-   }
+  if ((cp = strchr(Arg, ' ')) != NULL) {
+    *cp++ = 0;
+    while (*cp && *cp == ' ') {
+      cp++;
+    }
+  }
 
-   if(STRCMP(Arg,"add") == 0) {
-      if(cp != NULL && *cp) {
-         ACLAdd(p,pCC1,cp,bAllowed);
-      }
-      else {
-         BufPrintf(p,"Add who ?\r");
-         Rcode = TBD_ERR_ARG_COUNT;
-      }
-   }
-   else if(STRCMP(Arg,"delete") == 0) {
-      if(cp != NULL && *cp) {
-         ACLDelete(p,pCC1,cp,bAllowed);
-      }
-      else {
-         BufPrintf(p,"Delete who ?\r");
-         Rcode = TBD_ERR_ARG_COUNT;
-      }
-   }
-   else if(STRCMP(Arg,"list") == 0) {
-      ACLList(p,pCC1,Arg,bAllowed);
-   }
-   else {
-      Rcode = TBD_ERR_INVALID_CMD;
-      if(bAllowed) {
-         BufPrintf(p,"Usage:\r"
-                     "allow add <callsign> [<hostname/IP Address> [password [<User's name>]]]\r"
-                     "allow delete <callsign>\r"
-                     "allow list\r");
-      }
-      else {
-         BufPrintf(p,"Usage:\r"
-                     "ban add <callsign> [<hostname/IP Address>]\r"
-                     "ban delete <callsign>\r"
-                     "ban list\r");
-      }
-   }
+  if (STRCMP(Arg, "add") == 0) {
+    if (cp != NULL && *cp) {
+      ACLAdd(p, pCC1, cp, bAllowed);
+    } else {
+      BufPrintf(p, "Add who ?\r");
+      Rcode = TBD_ERR_ARG_COUNT;
+    }
+  } else if (STRCMP(Arg, "delete") == 0) {
+    if (cp != NULL && *cp) {
+      ACLDelete(p, pCC1, cp, bAllowed);
+    } else {
+      BufPrintf(p, "Delete who ?\r");
+      Rcode = TBD_ERR_ARG_COUNT;
+    }
+  } else if (STRCMP(Arg, "list") == 0) {
+    ACLList(p, pCC1, Arg, bAllowed);
+  } else {
+    Rcode = TBD_ERR_INVALID_CMD;
+    if (bAllowed) {
+      BufPrintf(p, "Usage:\r"
+                   "allow add <callsign> [<hostname/IP Address> [password "
+                   "[<User's name>]]]\r"
+                   "allow delete <callsign>\r"
+                   "allow list\r");
+    } else {
+      BufPrintf(p, "Usage:\r"
+                   "ban add <callsign> [<hostname/IP Address>]\r"
+                   "ban delete <callsign>\r"
+                   "ban list\r");
+    }
+  }
 }
 
-void CmdAllow(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   CmdACL(p,pCC1,Arg,TRUE);
+void CmdAllow(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  CmdACL(p, pCC1, Arg, TRUE);
 }
 
-void CmdBan(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   CmdACL(p,pCC1,Arg,FALSE);
+void CmdBan(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  CmdACL(p, pCC1, Arg, FALSE);
 }
 
+void SaveBulletinList() {
+  FILE *fp;
+  Bulletin *pBulletin = BulletinList;
 
-void SaveBulletinList()
-{
-   FILE *fp;
-   Bulletin *pBulletin = BulletinList;
+  if ((fp = fopen("bulletin.lst", "w")) != NULL) {
+    while (pBulletin != NULL) {
+      fprintf(fp, "%s\t%s\n", pBulletin->Filename, pBulletin->Description);
+      pBulletin = pBulletin->Link;
+    }
+    fclose(fp);
+  }
+}
 
-   if((fp = fopen("bulletin.lst","w")) != NULL) {
-      while(pBulletin != NULL) {
-         fprintf(fp,"%s\t%s\n",pBulletin->Filename,pBulletin->Description);
-         pBulletin = pBulletin->Link;
+void FreeBulletinList() {
+  Bulletin *pBulletin;
+
+  while (BulletinList != NULL) {
+    pBulletin = BulletinList;
+    BulletinList = pBulletin->Link;
+    free(pBulletin->Filename);
+    free(pBulletin->Description);
+    free(pBulletin->RunTime);
+    free(pBulletin);
+  }
+}
+
+int CmdListAdd(char *Filename, char *Desc) {
+  struct stat FileStats;
+  int AudioBlocks;
+  int RunningTime;
+  Bulletin *pBulletin;
+  int Ret = FALSE;
+
+  // check that the file exists and calculate approximate length
+  if (stat(Filename, &FileStats) == 0) {
+    // Each audio packet encodes 80 milliseconds of audio.  It consists
+    // of a file header plus a RTP header plus 4 GSM 6.10 encoded audio frames.
+    // Each GSM frame contains 33 bytes.  This calculation is approximate
+    // since it ignores text messages and timestamps, but it should be close
+    // enough for our purposes.
+
+    AudioBlocks = FileStats.st_size /
+                  ((4 * 33) + sizeof(rtp_hdr_t) -
+                   sizeof(u_int32) /* optional csrc field not sent */ +
+                   sizeof(FilePacketHdr));
+
+    RunningTime = AudioBlocks * 2 / 25; // 12.5 packets/second of audio
+
+    pBulletin = (Bulletin *)malloc(sizeof(Bulletin));
+    if (pBulletin != NULL) {
+      pBulletin->Filename = strdup(Filename);
+      pBulletin->Description = strdup(Desc);
+      pBulletin->RunTime = strdup(DeltaTime2String(0, RunningTime, TRUE));
+      pBulletin->Link = NULL;
+      if (BulletinList == NULL) {
+        BulletinList = pBulletin;
+      } else {
+        BulletinListTail->Link = pBulletin;
       }
-      fclose(fp);
-   }
+      BulletinListTail = pBulletin;
+
+      Ret = TRUE;
+    }
+  }
+
+  return Ret;
 }
 
-void FreeBulletinList()
-{
-   Bulletin *pBulletin;
+void LoadBulletinList() {
+  FILE *fp;
+  char Line[80];
+  char *cp;
 
-   while(BulletinList != NULL) {
-      pBulletin = BulletinList;
-      BulletinList = pBulletin->Link;
+  FreeBulletinList();
+  if ((fp = fopen("bulletin.lst", "r")) != NULL) {
+    while (fgets(Line, sizeof(Line), fp) != NULL) {
+      if ((cp = strchr(Line, '\n')) != NULL) {
+        *cp = 0;
+      }
+
+      if ((cp = strchr(Line, '\t')) != NULL) {
+        *cp++ = 0;
+        CmdListAdd(Line, cp);
+      }
+    }
+    fclose(fp);
+  }
+}
+
+void CmdBulletinDelete(ClientInfo *p, ConfClient *pCC, char *Filename) {
+  Bulletin *pLast = (Bulletin *)&BulletinList;
+  Bulletin *pBulletin = BulletinList;
+
+  while (pBulletin != NULL) {
+    if (STRCMP(pBulletin->Filename, Filename) == 0) {
+      BufPrintf(p, "%s deleted\r", Filename);
+      pLast->Link = pBulletin->Link;
       free(pBulletin->Filename);
       free(pBulletin->Description);
-      free(pBulletin->RunTime);
       free(pBulletin);
-   }
+      SaveBulletinList();
+      break;
+    }
+    pLast = pBulletin;
+    pBulletin = pBulletin->Link;
+  }
+
+  if (pBulletin == NULL) {
+    BufPrintf(p, "%s not found\r", Filename);
+  }
 }
 
-int CmdListAdd(char *Filename,char *Desc)
-{
-   struct stat FileStats;
-   int AudioBlocks;
-   int RunningTime;
-   Bulletin *pBulletin;
-   int Ret = FALSE;
-
-   // check that the file exists and calculate approximate length
-   if(stat(Filename,&FileStats) == 0) {
-   // Each audio packet encodes 80 milliseconds of audio.  It consists
-   // of a file header plus a RTP header plus 4 GSM 6.10 encoded audio frames.  
-   // Each GSM frame contains 33 bytes.  This calculation is approximate
-   // since it ignores text messages and timestamps, but it should be close
-   // enough for our purposes.
-      
-      AudioBlocks = FileStats.st_size / 
-                        ((4 * 33) + 
-                         sizeof(rtp_hdr_t) - 
-                         sizeof(u_int32) /* optional csrc field not sent */ + 
-                         sizeof(FilePacketHdr));
-
-      RunningTime = AudioBlocks * 2 / 25; // 12.5 packets/second of audio
-
-      pBulletin = (Bulletin *) malloc(sizeof(Bulletin));
-      if(pBulletin != NULL) {
-         pBulletin->Filename = strdup(Filename);
-         pBulletin->Description = strdup(Desc);
-         pBulletin->RunTime = strdup(DeltaTime2String(0,RunningTime,TRUE));
-         pBulletin->Link = NULL;
-         if(BulletinList == NULL) {
-            BulletinList = pBulletin;
-         }
-         else {
-            BulletinListTail->Link = pBulletin;
-         }
-         BulletinListTail = pBulletin;
-
-         Ret = TRUE;
-      }
-   }
-
-   return Ret;
+void CmdXyzzy(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  BufPrintf(p, "Nothing happens\r");
 }
 
-void LoadBulletinList()
-{
-   FILE *fp;
-   char  Line[80];
-   char *cp;
+void CmdList(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  char *cp;
+  char *cp1 = NULL;
+  int i;
+  Bulletin *pBulletin = BulletinList;
 
-   FreeBulletinList();
-   if((fp = fopen("bulletin.lst","r")) != NULL) {
-      while(fgets(Line,sizeof(Line),fp) != NULL) {
-         if((cp = strchr(Line,'\n')) != NULL) {
-            *cp = 0;
-         }
+  if ((cp = strchr(Arg, ' ')) != NULL) {
+    *cp++ = 0;
+    while (*cp && *cp == ' ') {
+      cp++;
+    }
 
-         if((cp = strchr(Line,'\t')) != NULL) {
-            *cp++ = 0;
-            CmdListAdd(Line,cp);
-         }
+    if ((cp1 = strchr(cp, ' ')) != NULL) {
+      *cp1++ = 0;
+      while (*cp1 && *cp1 == ' ') {
+        cp1++;
       }
-      fclose(fp);
-   }
+    }
+  }
+
+  if (pCC->bAdmin && cp != NULL && *cp) {
+    if (STRCMP(Arg, "add") == 0) {
+      if (cp != NULL && cp1 != NULL) {
+        if (CmdListAdd(cp, cp1)) {
+          SaveBulletinList();
+          BufPrintf(p, "Added: %s as %s\r", cp, cp1);
+        } else {
+          BufPrintf(p, "File \"%s\" not found.\r", cp);
+        }
+      } else {
+        BufPrintf(p, "usage: list add <filename> <description>\r");
+        Rcode = TBD_ERR_INVALID_CMD;
+      }
+    } else if (STRCMP(Arg, "delete") == 0) {
+      if (cp != NULL) {
+        CmdBulletinDelete(p, pCC, cp);
+      } else {
+        BufPrintf(p, "usage: list delete <filename>\r");
+        Rcode = TBD_ERR_INVALID_CMD;
+      }
+    } else {
+      BufPrintf(p, "Usage:\r"
+                   "list add <filename> <description>\r"
+                   "list delete <filename>\r");
+      Rcode = TBD_ERR_INVALID_CMD;
+    }
+  } else {
+    // Normal client or just bare list command
+
+    i = 1;
+    if (pBulletin == NULL) {
+      BufPrintf(p, "Sorry, no bulletins are available at this time.\r");
+    } else {
+      BufPrintf(p, "Bulletins:\r");
+      while (pBulletin != NULL) {
+        if (pCC->bAdmin) {
+          BufPrintf(p, "%d. (%s) %s (%s)\r", i++, pBulletin->Filename,
+                    pBulletin->Description, pBulletin->RunTime);
+        } else {
+          BufPrintf(p, "%d. %s (%s)\r", i++, pBulletin->Description,
+                    pBulletin->RunTime);
+        }
+        pBulletin = pBulletin->Link;
+      }
+    }
+  }
 }
 
-void CmdBulletinDelete(ClientInfo *p,ConfClient *pCC,char *Filename)
-{
-   Bulletin *pLast = (Bulletin *) &BulletinList;
-   Bulletin *pBulletin = BulletinList;
+void PlayBackComplete(ConfClient *pCC, char *Reason) {
+  ClientFileIO *pFIO = (ClientFileIO *)pCC->p;
+  ConfServer *pCS = pCC->pCS;
 
-   while(pBulletin != NULL) {
-      if(STRCMP(pBulletin->Filename,Filename) == 0) {
-         BufPrintf(p,"%s deleted\r",Filename);
-         pLast->Link = pBulletin->Link;
-         free(pBulletin->Filename);
-         free(pBulletin->Description);
-         free(pBulletin);
-         SaveBulletinList();
-         break;
-      }
-      pLast = pBulletin;
-      pBulletin = pBulletin->Link;
-   }
+  if (pFIO != NULL) {
+    EventHook("playbackcomplete %s %s", pCC->Callsign, Reason);
+    LOG_NORM(("PlayBackComplete() for %s, %s.\n", pCC->Callsign, Reason));
 
-   if(pBulletin == NULL) {
-      BufPrintf(p,"%s not found\r",Filename);
-   }
+    FileCleanup(pCC);
+  } else {
+    LOG_NORM(("PlayBackComplete() Error, pCC->p == NULL for %s, %s.\n",
+              pCC->Callsign, Reason));
+  }
+
+  if (AudioTestConf && FileRecord(NULL, pCC, EVENT_INIT)) {
+    pCC->bInConf = FALSE;
+    pCC->State = FileRecord;
+  } else if (pCC->bFilePlayer) {
+    pCC->pCS->bPlayWhenFree = FALSE;
+    pCC->pCS->pFilePlayer = NULL;
+    if (ClientTalking == pCC) {
+      ClientTalking = NULL;
+    } else {
+      LOG_ERROR(("PlayBackComplete(): ClientTalking is not us.\n"));
+    }
+    DeleteCClient(pCC);
+    SendStationList(pCS);
+    pCS->bSendStationList = FALSE;
+  } else {
+    pCC->bInConf = TRUE;
+    pCC->State = NULL;
+  }
 }
 
-void CmdXyzzy(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   BufPrintf(p,"Nothing happens\r");
+void StartPlayback(ClientInfo *p, ConfClient *pCC) {
+  ClientInfo *pPB;
+  ClientFileIO *pFIO = (ClientFileIO *)pCC->p;
+
+  // Create a mainloop client to playback the file
+  pPB = CreateNewClient();
+  if (pPB == NULL) {
+    LOG_ERROR(("FileRecord(): CreateNewClient failed.\n"));
+    PlayBackComplete(pCC, "CreateNewClient() failed");
+  } else {
+    // Wait a second and then start playing it back
+    pFIO->TimeFirstTx.tv_sec = 0;
+    pFIO->pClient = pPB;
+    pPB->p = pFIO;
+    pPB->HisAdr = pCC->HisAdr;
+    pPB->Socket = p->Socket;
+    pPB->State = FilePlayBack;
+    pPB->BufSize = CONF_BUF_SIZE;
+    pPB->Buf = malloc(pPB->BufSize);
+    if (pCC->bFilePlayer) {
+      SetTimeout(pPB, 1);
+    } else {
+      SetTimeout(pPB, 1000);
+    }
+    avl_insert(ClientTree, pPB);
+    pPB->bInClientTree = TRUE;
+  }
 }
 
-void CmdList(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   char *cp;
-   char *cp1 = NULL;
-   int i;
-   Bulletin *pBulletin = BulletinList;
+void OpenAudioFile(ConfClient *pCC, char *Filename, char *Mode) {
+  ClientFileIO *pFIO;
+  FILE *fp;
 
-   if((cp = strchr(Arg,' ')) != NULL) {
-      *cp++ = 0;
-      while(*cp && *cp == ' ') {
-         cp++;
-      }
+  if (pCC->bFileIOActive) {
+    // A file is currently playing for this client, cancel it
+    PlayBackComplete(pCC, "opening a new file");
+  }
 
-      if((cp1 = strchr(cp,' ')) != NULL) {
-         *cp1++ = 0;
-         while(*cp1 && *cp1 == ' ') {
-            cp1++;
-         }
-      }
-   }
-
-   if(pCC->bAdmin && cp != NULL && *cp) {
-      if(STRCMP(Arg,"add") == 0) {
-         if(cp != NULL && cp1 != NULL) {
-            if(CmdListAdd(cp,cp1)) {
-               SaveBulletinList();
-               BufPrintf(p,"Added: %s as %s\r",cp,cp1);
-            }
-            else {
-               BufPrintf(p,"File \"%s\" not found.\r",cp);
-            }
-         }
-         else {
-            BufPrintf(p,"usage: list add <filename> <description>\r");
-            Rcode = TBD_ERR_INVALID_CMD;
-         }
-      }
-      else if(STRCMP(Arg,"delete") == 0) {
-         if(cp != NULL) {
-            CmdBulletinDelete(p,pCC,cp);
-         }
-         else {
-            BufPrintf(p,"usage: list delete <filename>\r");
-            Rcode = TBD_ERR_INVALID_CMD;
-         }
-      }
-      else {
-         BufPrintf(p,"Usage:\r"
-                     "list add <filename> <description>\r"
-                     "list delete <filename>\r");
-         Rcode = TBD_ERR_INVALID_CMD;
-      }
-   }
-   else {
-   // Normal client or just bare list command
-
-      i = 1;
-      if(pBulletin == NULL) {
-         BufPrintf(p,"Sorry, no bulletins are available at this time.\r");
-      }
-      else {
-         BufPrintf(p,"Bulletins:\r");
-         while(pBulletin != NULL) {
-            if(pCC->bAdmin) {
-               BufPrintf(p,"%d. (%s) %s (%s)\r",i++,pBulletin->Filename,
-                         pBulletin->Description,pBulletin->RunTime);
-            }
-            else {
-               BufPrintf(p,"%d. %s (%s)\r",i++,pBulletin->Description,
-                         pBulletin->RunTime);
-            }
-            pBulletin = pBulletin->Link;
-         }
-      }
-   }
-}
-
-void PlayBackComplete(ConfClient *pCC,char *Reason)
-{
-   ClientFileIO *pFIO = (ClientFileIO *) pCC->p;
-   ConfServer *pCS = pCC->pCS;
-
-   if(pFIO != NULL) {
-      EventHook("playbackcomplete %s %s",pCC->Callsign,Reason);
-      LOG_NORM(("PlayBackComplete() for %s, %s.\n",pCC->Callsign,Reason));
-
-      FileCleanup(pCC);
-   }
-   else {
-      LOG_NORM(("PlayBackComplete() Error, pCC->p == NULL for %s, %s.\n",
-                pCC->Callsign,Reason));
-   }
-
-   if(AudioTestConf && FileRecord(NULL,pCC,EVENT_INIT)) {
+  if ((fp = FOPEN(Filename, Mode)) != NULL) {
+    pFIO = (ClientFileIO *)(pCC->p = malloc(sizeof(ClientFileIO)));
+    if (pFIO != NULL) {
+      pCC->bFileIOActive = TRUE;
       pCC->bInConf = FALSE;
-      pCC->State = FileRecord;
-   }
-   else if(pCC->bFilePlayer) {
-      pCC->pCS->bPlayWhenFree = FALSE;
-      pCC->pCS->pFilePlayer = NULL;
-      if(ClientTalking == pCC) {
-         ClientTalking = NULL;
-      }
-      else {
-         LOG_ERROR(("PlayBackComplete(): ClientTalking is not us.\n"));
-      }
-      DeleteCClient(pCC);
-      SendStationList(pCS);
-      pCS->bSendStationList = FALSE;
-   }
-   else {
-      pCC->bInConf = TRUE;
-      pCC->State = NULL;
-   }
+      memset(pFIO, 0, sizeof(*pFIO));
+      pFIO->fp = fp;
+      pFIO->pCC = pCC;
+      pFIO->Filename = strdup(Filename);
+      pFIO->Timeout = 80; // Assume a perfect delay at first
+    } else {
+      LOG_ERROR(("OpenAudioFile(): malloc failed.\n"));
+    }
+  } else {
+    LOG_ERROR(("OpenAudioFile: Unable to open \"%s\", %s.\n", Filename,
+               Err2String(errno)));
+  }
 }
-
-void StartPlayback(ClientInfo *p,ConfClient *pCC)
-{
-   ClientInfo *pPB;
-   ClientFileIO *pFIO = (ClientFileIO *) pCC->p;
-
-// Create a mainloop client to playback the file
-   pPB = CreateNewClient();
-   if(pPB == NULL) {
-      LOG_ERROR(("FileRecord(): CreateNewClient failed.\n"));
-      PlayBackComplete(pCC,"CreateNewClient() failed");
-   }
-   else {
-   // Wait a second and then start playing it back
-      pFIO->TimeFirstTx.tv_sec = 0;
-      pFIO->pClient = pPB;
-      pPB->p = pFIO;
-      pPB->HisAdr = pCC->HisAdr;
-      pPB->Socket = p->Socket;
-      pPB->State = FilePlayBack;
-      pPB->BufSize = CONF_BUF_SIZE;
-      pPB->Buf = malloc(pPB->BufSize);
-      if(pCC->bFilePlayer) {
-         SetTimeout(pPB,1);
-      }
-      else {
-         SetTimeout(pPB,1000);
-      }
-      avl_insert(ClientTree,pPB);
-      pPB->bInClientTree = TRUE;
-   }
-}
-
-void OpenAudioFile(ConfClient *pCC,char *Filename, char *Mode)
-{
-   ClientFileIO *pFIO;
-   FILE *fp;
-
-   if(pCC->bFileIOActive) {
-   // A file is currently playing for this client, cancel it
-      PlayBackComplete(pCC,"opening a new file");
-   }
-   
-   if((fp = FOPEN(Filename,Mode)) != NULL) {
-      pFIO = (ClientFileIO *) (pCC->p = malloc(sizeof(ClientFileIO)));
-      if(pFIO != NULL) {
-         pCC->bFileIOActive = TRUE;
-         pCC->bInConf = FALSE;
-         memset(pFIO,0,sizeof(*pFIO));
-         pFIO->fp = fp;
-         pFIO->pCC = pCC;
-         pFIO->Filename = strdup(Filename);
-         pFIO->Timeout = 80;   // Assume a perfect delay at first
-      }
-      else {
-         LOG_ERROR(("OpenAudioFile(): malloc failed.\n"));
-      }
-   }
-   else {
-      LOG_ERROR(("OpenAudioFile: Unable to open \"%s\", %s.\n",
-                 Filename,Err2String(errno)));
-   }
-}
-
 
 // play4 [-f] [-i] [-u callsign] filename [displayed name]
 // -f = force file to play now even if someone is talking
 // -i = play when conference becomes idle (IdleTimeout seconds of inactivity)
 // -u = play for specified user only
-void CmdPlayFor(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   int bForced = FALSE;
-   int bWhenIdle = FALSE;
-   int bIdle   = FALSE;
-   int bFileFoundErr = FALSE;
-   ConfClient *pCC = NULL;
-   ConfServer *pCS = (ConfServer *) p->p;
-   char *cp = Arg;
-   char *cp1;
-   char *Filename = NULL;
-   char CharSave;
-   struct avl_traverser avl_trans;
+void CmdPlayFor(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  int bForced = FALSE;
+  int bWhenIdle = FALSE;
+  int bIdle = FALSE;
+  int bFileFoundErr = FALSE;
+  ConfClient *pCC = NULL;
+  ConfServer *pCS = (ConfServer *)p->p;
+  char *cp = Arg;
+  char *cp1;
+  char *Filename = NULL;
+  char CharSave;
+  struct avl_traverser avl_trans;
 
-   while(*cp == '-') {
-      switch(cp[1]) {
-         case 'f':
-            bForced = TRUE;
-            break;
+  while (*cp == '-') {
+    switch (cp[1]) {
+    case 'f':
+      bForced = TRUE;
+      break;
 
-         case 'i':
-            bWhenIdle = TRUE;
-            break;
+    case 'i':
+      bWhenIdle = TRUE;
+      break;
 
-         case 'u':
-            cp += 2;
-            while(*cp && *cp == ' ') {
-               cp++;
-            }
-            cp1 = cp;
-            while(*cp1 && *cp1 != ' ') {
-               cp1++;
-            }
-            CharSave = *cp1;
-            *cp1 = 0;
-
-            pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-            while(pCC!= NULL) {
-               if(STRCMP(cp,pCC->Callsign) == 0) {
-                  break;
-               }
-               pCC = (ConfClient *) avl_t_next(&avl_trans);
-            }
-            *cp1 = CharSave;
-            cp = cp1 - 2;
-
-            if(pCC == NULL) {
-               BufPrintf(p,"%s not found\r",cp);
-               Rcode = TBD_STATION_NOT_FOUND;
-               cp = NULL;
-            }
-            break;
-
-         default:
-            BufPrintf(p,"Error: Unknown option '%c'\r",cp[1]);
-            cp = NULL;
-            Rcode = TBD_ERR_INVALID_ARG;
-            break;
+    case 'u':
+      cp += 2;
+      while (*cp && *cp == ' ') {
+        cp++;
       }
-      
-      if(cp == NULL) {
-         break;
+      cp1 = cp;
+      while (*cp1 && *cp1 != ' ') {
+        cp1++;
       }
-      else {
-         cp += 2;
-         while(*cp && *cp == ' ') {
-            cp++;
-         }
-      }
-   }
+      CharSave = *cp1;
+      *cp1 = 0;
 
-   if(cp != NULL) {
-   // No error yet
-      Filename = cp;
-      if((cp = strchr(cp,' ')) != NULL) {
-         while(*cp == ' ') {
-            *cp++ = 0;
-         }
+      pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+      while (pCC != NULL) {
+        if (STRCMP(cp, pCC->Callsign) == 0) {
+          break;
+        }
+        pCC = (ConfClient *)avl_t_next(&avl_trans);
       }
+      *cp1 = CharSave;
+      cp = cp1 - 2;
 
-      if(pCC != NULL) {
+      if (pCC == NULL) {
+        BufPrintf(p, "%s not found\r", cp);
+        Rcode = TBD_STATION_NOT_FOUND;
+        cp = NULL;
+      }
+      break;
+
+    default:
+      BufPrintf(p, "Error: Unknown option '%c'\r", cp[1]);
+      cp = NULL;
+      Rcode = TBD_ERR_INVALID_ARG;
+      break;
+    }
+
+    if (cp == NULL) {
+      break;
+    } else {
+      cp += 2;
+      while (*cp && *cp == ' ') {
+        cp++;
+      }
+    }
+  }
+
+  if (cp != NULL) {
+    // No error yet
+    Filename = cp;
+    if ((cp = strchr(cp, ' ')) != NULL) {
+      while (*cp == ' ') {
+        *cp++ = 0;
+      }
+    }
+
+    if (pCC != NULL) {
       // Playing for a specified user
-         OpenAudioFile(pCC,Filename,MODE_RD_BIN);
-         if(pCC->bFileIOActive) {
-         // Playing for one station
-            StartPlayback(p,pCC);
-            BufPrintf(p,"Playing %s.\r",Filename);
-         }
-         else {
-            bFileFoundErr = TRUE;
-         }
+      OpenAudioFile(pCC, Filename, MODE_RD_BIN);
+      if (pCC->bFileIOActive) {
+        // Playing for one station
+        StartPlayback(p, pCC);
+        BufPrintf(p, "Playing %s.\r", Filename);
+      } else {
+        bFileFoundErr = TRUE;
       }
-      else {
+    } else {
       // Playing for everyone
-         pCC = CreateNewConfClient();
-         pCC->bFilePlayer = TRUE;
-         pCC->pCS = pCS;
-         pCC->Proto = PROTO_ILINK;
-         pCC->CompressionType = RTP_PT_GSM;
+      pCC = CreateNewConfClient();
+      pCC->bFilePlayer = TRUE;
+      pCC->pCS = pCS;
+      pCC->Proto = PROTO_ILINK;
+      pCC->CompressionType = RTP_PT_GSM;
 
-         OpenAudioFile(pCC,Filename,MODE_RD_BIN);
-         if(pCC->bFileIOActive) {
-            pCC->bInConf = TRUE;
-            if(cp == NULL) {
-               cp = "QST";
-            }
-            pCC->CallPlus = strdup(cp);
-            pCC->Callsign = strdup(cp);
-            pCC->HisAdr.ADDR = inet_addr("127.0.0.1");
-            if(pCS->pFilePlayer != NULL) {
-               PlayBackComplete(pCS->pFilePlayer,"starting new playback 1");
-            }
-            pCS->pFilePlayer = pCC;
+      OpenAudioFile(pCC, Filename, MODE_RD_BIN);
+      if (pCC->bFileIOActive) {
+        pCC->bInConf = TRUE;
+        if (cp == NULL) {
+          cp = "QST";
+        }
+        pCC->CallPlus = strdup(cp);
+        pCC->Callsign = strdup(cp);
+        pCC->HisAdr.ADDR = inet_addr("127.0.0.1");
+        if (pCS->pFilePlayer != NULL) {
+          PlayBackComplete(pCS->pFilePlayer, "starting new playback 1");
+        }
+        pCS->pFilePlayer = pCC;
 
-            if(ClientTalking == NULL) {
-               if(TimeNow.tv_sec - pCS->LastAudioIn.tv_sec > IdleTimeout) {
-                  bIdle = TRUE;
-               }
-            }
+        if (ClientTalking == NULL) {
+          if (TimeNow.tv_sec - pCS->LastAudioIn.tv_sec > IdleTimeout) {
+            bIdle = TRUE;
+          }
+        }
 
-            EndPoint(p,pCC,EVENT_INIT);
-            if(bForced || (!bWhenIdle && ClientTalking == NULL) || 
-               (bWhenIdle && bIdle))
-            {
-               ClientTalking = pCC;
-               pCC->FirstAudioIn = TimeNow;
-               StartPlayback(p,pCC);
-               BufPrintf(p,"Playing %s.\r",Filename);
-            }
-            else if(bWhenIdle) {
-               pCS->bPlayWhenIdle = TRUE;
-               BufPrintf(p,"%s set to play when the conference becomes idle.\r",
-                         Filename);
-            }
-            else {
-               pCS->bPlayWhenFree = TRUE;
-               BufPrintf(p,"%s set to play when the conference becomes free.\r",
-                         Filename);
-            }
-         }
-         else {
-            bFileFoundErr = TRUE;
-         }
+        EndPoint(p, pCC, EVENT_INIT);
+        if (bForced || (!bWhenIdle && ClientTalking == NULL) ||
+            (bWhenIdle && bIdle)) {
+          ClientTalking = pCC;
+          pCC->FirstAudioIn = TimeNow;
+          StartPlayback(p, pCC);
+          BufPrintf(p, "Playing %s.\r", Filename);
+        } else if (bWhenIdle) {
+          pCS->bPlayWhenIdle = TRUE;
+          BufPrintf(p, "%s set to play when the conference becomes idle.\r",
+                    Filename);
+        } else {
+          pCS->bPlayWhenFree = TRUE;
+          BufPrintf(p, "%s set to play when the conference becomes free.\r",
+                    Filename);
+        }
+      } else {
+        bFileFoundErr = TRUE;
       }
-   }
+    }
+  }
 
-   if(bFileFoundErr) {
-      BufPrintf(p,"%s not found.\r",Filename);
-      Rcode = TBD_ERR_FILE_OPEN;
-   }
+  if (bFileFoundErr) {
+    BufPrintf(p, "%s not found.\r", Filename);
+    Rcode = TBD_ERR_FILE_OPEN;
+  }
 }
 
-void CmdPlay(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   int Selection;
-   Bulletin *pBulletin = BulletinList;
+void CmdPlay(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  int Selection;
+  Bulletin *pBulletin = BulletinList;
 
-   if(pCC->bFileIOActive) {
-      PlayBackComplete(pCC,"starting new playback");
-   }
+  if (pCC->bFileIOActive) {
+    PlayBackComplete(pCC, "starting new playback");
+  }
 
-   if(sscanf(Arg,"%d",&Selection) == 1) {
-      while(Selection != 1 && pBulletin != NULL) {
-         Selection--;
-         pBulletin = pBulletin->Link;
+  if (sscanf(Arg, "%d", &Selection) == 1) {
+    while (Selection != 1 && pBulletin != NULL) {
+      Selection--;
+      pBulletin = pBulletin->Link;
+    }
+
+    if (Selection == 1 && pBulletin != NULL) {
+      OpenAudioFile(pCC, pBulletin->Filename, MODE_RD_BIN);
+      if (pCC->bFileIOActive) {
+        StartPlayback(p, pCC);
       }
+    }
+  }
 
-      if(Selection == 1 && pBulletin != NULL) {
-         OpenAudioFile(pCC,pBulletin->Filename,MODE_RD_BIN);
-         if(pCC->bFileIOActive) {
-            StartPlayback(p,pCC);
-         }
-      }
-   }
-
-   if(pCC->bFileIOActive) {
-      BufPrintf(p,"Playing bulletin %s.\r"
-                "Enter .stop to end, or just disconnect.\r",Arg);
-   }
-   else {
-      BufPrintf(p,"Usage: .play <bulletin number>\r"
-                  " hint: use the list command to find the bulletins.\r");
-   }
+  if (pCC->bFileIOActive) {
+    BufPrintf(p,
+              "Playing bulletin %s.\r"
+              "Enter .stop to end, or just disconnect.\r",
+              Arg);
+  } else {
+    BufPrintf(p, "Usage: .play <bulletin number>\r"
+                 " hint: use the list command to find the bulletins.\r");
+  }
 }
 
-void CmdQuit(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   BufPrintf(p,"Exiting\r");
-   bRunning = FALSE;
+void CmdQuit(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  BufPrintf(p, "Exiting\r");
+  bRunning = FALSE;
 }
 
-void CmdQuote(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   
-   BufPrintf(p,"%s>%s\r",ConferenceCall,Arg);
-   
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(pCC->bTBD || pCC->bSysop) {
-         Send2(pCC,p->Buf,p->Count,FALSE);
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-   pCC1->bSentQuotedCmd = TRUE;
-   pCC1->FirstAudioIn = TimeNow;
+void CmdQuote(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
 
-   p->Count = 0;  // reinit for BufPrintf
-   BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
+  BufPrintf(p, "%s>%s\r", ConferenceCall, Arg);
+
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (pCC->bTBD || pCC->bSysop) {
+      Send2(pCC, p->Buf, p->Count, FALSE);
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+  pCC1->bSentQuotedCmd = TRUE;
+  pCC1->FirstAudioIn = TimeNow;
+
+  p->Count = 0; // reinit for BufPrintf
+  BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
 }
 
-void CmdStop(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   ConfServer *pCS = (ConfServer *) p->p;
+void CmdStop(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  ConfServer *pCS = (ConfServer *)p->p;
 
-   if(pCC->bFileIOActive) {
-      BufPrintf(p,"Playback stopped.\r");
-      PlayBackComplete(pCC,"stop command");
-   }
-   else if(pCS->pFilePlayer != NULL && 
-           ((ClientFileIO *) pCS->pFilePlayer->p)->pClient != NULL)
-   {
-      PlayBackComplete(pCS->pFilePlayer,"stop command");
-   }
-   else {
-      BufPrintf(p,"Error: Nothing is playing.\r");
-   }
+  if (pCC->bFileIOActive) {
+    BufPrintf(p, "Playback stopped.\r");
+    PlayBackComplete(pCC, "stop command");
+  } else if (pCS->pFilePlayer != NULL &&
+             ((ClientFileIO *)pCS->pFilePlayer->p)->pClient != NULL) {
+    PlayBackComplete(pCS->pFilePlayer, "stop command");
+  } else {
+    BufPrintf(p, "Error: Nothing is playing.\r");
+  }
 }
 
-int SendAudioFromFile(ClientInfo *p,ClientFileIO *pFIO,int NumPackets)
-{
-   FilePacketHdr PktHdr;
-   int Ret = 0;
-   time_t TimeStamp;
-   int PlayBackPause = 0;
-   ConfClient *pCC = pFIO->pCC;
-   ConfServer *pCS = pCC->pCS;
-   int TotalDelta = 0;
-   rtp_hdr_t *pRTP;
+int SendAudioFromFile(ClientInfo *p, ClientFileIO *pFIO, int NumPackets) {
+  FilePacketHdr PktHdr;
+  int Ret = 0;
+  time_t TimeStamp;
+  int PlayBackPause = 0;
+  ConfClient *pCC = pFIO->pCC;
+  ConfServer *pCS = pCC->pCS;
+  int TotalDelta = 0;
+  rtp_hdr_t *pRTP;
 
-   if(MaxPlayWithoutPause > 0 && pFIO->TimeFirstTx.tv_sec != 0) {
-      TotalDelta = ((TimeNow.tv_sec - pFIO->TimeFirstTx.tv_sec) * 1000) +
-                   ((TimeNow.tv_usec - pFIO->TimeFirstTx.tv_usec) / 1000);
-   
-      if(TotalDelta > (MaxPlayWithoutPause * 1000)) {
+  if (MaxPlayWithoutPause > 0 && pFIO->TimeFirstTx.tv_sec != 0) {
+    TotalDelta = ((TimeNow.tv_sec - pFIO->TimeFirstTx.tv_sec) * 1000) +
+                 ((TimeNow.tv_usec - pFIO->TimeFirstTx.tv_usec) / 1000);
+
+    if (TotalDelta > (MaxPlayWithoutPause * 1000)) {
       // time to pause for a while
-         if(MinPlayBackPause > 0) {
-            PlayBackPause = MinPlayBackPause;
-         }
-         else {
-            PlayBackPause = 5;
-         }
-         Ret = 2;
+      if (MinPlayBackPause > 0) {
+        PlayBackPause = MinPlayBackPause;
+      } else {
+        PlayBackPause = 5;
       }
-   }
+      Ret = 2;
+    }
+  }
 
-   while(Ret != 2 && NumPackets--) {
-      if(fread(&PktHdr,sizeof(PktHdr),1,pFIO->fp) != 1) {
-         if(feof(pFIO->fp)) {
-            LOG_ERROR(("SendAudioFromFile(): unexpected end of file\n"));
-         }
-         else {
-            LOG_ERROR(("SendAudioFromFile(): fread failed, %s",
-                       Err2String(errno)));
-         }
-         D3PRINTF(("Reading header\n"));
-         break;
+  while (Ret != 2 && NumPackets--) {
+    if (fread(&PktHdr, sizeof(PktHdr), 1, pFIO->fp) != 1) {
+      if (feof(pFIO->fp)) {
+        LOG_ERROR(("SendAudioFromFile(): unexpected end of file\n"));
+      } else {
+        LOG_ERROR(("SendAudioFromFile(): fread failed, %s", Err2String(errno)));
       }
+      D3PRINTF(("Reading header\n"));
+      break;
+    }
 
-      PktHdr.Flags = ntohl(PktHdr.Flags);
-      PktHdr.Len = ntohl(PktHdr.Len);
+    PktHdr.Flags = ntohl(PktHdr.Flags);
+    PktHdr.Len = ntohl(PktHdr.Len);
 
-      D3PRINTF(("SendAudioFromFile(): PktHdr.Len = %d, PktHdr.Flags = 0x%x\n",
-                PktHdr.Len,PktHdr.Flags));
+    D3PRINTF(("SendAudioFromFile(): PktHdr.Len = %d, PktHdr.Flags = 0x%x\n",
+              PktHdr.Len, PktHdr.Flags));
 
-      if(PktHdr.Flags & FILE_FLAG_TIME_STAMP) {
+    if (PktHdr.Flags & FILE_FLAG_TIME_STAMP) {
       // A timestamp header, pause playback
-         TimeStamp = (time_t) PktHdr.Len;
-         if(pFIO->FirstTimeStamp == 0) {
-            pFIO->FirstTimeStamp = TimeStamp;
-         }
-
-         if(pFIO->LastTimeStamp != 0) {
-            PlayBackPause = TimeStamp - pFIO->LastTimeStamp;
-            if(PlayBackPause > MaxPlayBackPause) {
-               PlayBackPause = MaxPlayBackPause;
-            }
-            else if(PlayBackPause < MinPlayBackPause) {
-               PlayBackPause = MinPlayBackPause;
-            }
-         }
-         else {
-            PlayBackPause = MinPlayBackPause;
-         }
-         pFIO->LastTimeStamp = TimeStamp;
-         Ret = 2;
-         break;
+      TimeStamp = (time_t)PktHdr.Len;
+      if (pFIO->FirstTimeStamp == 0) {
+        pFIO->FirstTimeStamp = TimeStamp;
       }
 
-      if(PktHdr.Len > CONF_BUF_SIZE || PktHdr.Len < 0) {
-         LOG_ERROR(("SendAudioFromFile(): Len > CONF_BUF_SIZE (%d).\n",
-                    PktHdr.Len));
-         break;
+      if (pFIO->LastTimeStamp != 0) {
+        PlayBackPause = TimeStamp - pFIO->LastTimeStamp;
+        if (PlayBackPause > MaxPlayBackPause) {
+          PlayBackPause = MaxPlayBackPause;
+        } else if (PlayBackPause < MinPlayBackPause) {
+          PlayBackPause = MinPlayBackPause;
+        }
+      } else {
+        PlayBackPause = MinPlayBackPause;
       }
+      pFIO->LastTimeStamp = TimeStamp;
+      Ret = 2;
+      break;
+    }
 
-      if(PktHdr.Len == 0) {
-         D2PRINTF(("SendAudioFromFile(): playback complete.\n"));
-         break;
+    if (PktHdr.Len > CONF_BUF_SIZE || PktHdr.Len < 0) {
+      LOG_ERROR(
+          ("SendAudioFromFile(): Len > CONF_BUF_SIZE (%d).\n", PktHdr.Len));
+      break;
+    }
+
+    if (PktHdr.Len == 0) {
+      D2PRINTF(("SendAudioFromFile(): playback complete.\n"));
+      break;
+    }
+
+    if (fread(p->Buf, PktHdr.Len, 1, pFIO->fp) != 1) {
+      if (feof(pFIO->fp)) {
+        LOG_ERROR(("SendAudioFromFile(): unexpected end of file\n"));
+      } else {
+        LOG_ERROR(("SendAudioFromFile(): fread failed, %s", Err2String(errno)));
       }
+      break;
+    }
+    pRTP = (rtp_hdr_t *)p->Buf;
 
-      if(fread(p->Buf,PktHdr.Len,1,pFIO->fp) != 1) {
-         if(feof(pFIO->fp)) {
-            LOG_ERROR(("SendAudioFromFile(): unexpected end of file\n"));
-         }
-         else {
-            LOG_ERROR(("SendAudioFromFile(): fread failed, %s",
-                       Err2String(errno)));
-         }
-         break;
+    if (!pCC->bFilePlayer) {
+      if (pCC->Proto != PROTO_ILINK) {
+        ProtoData *pPDat = pFIO->pPDat;
+        int Len;
+
+        // playing for a non-EchoLink client
+        if (pPDat == NULL) {
+          if ((pPDat = malloc(sizeof(ProtoData) * NUM_PROTOCOLS)) == NULL) {
+            LOG_ERROR(("SendAudioFromFile: malloc failed.\n"));
+          } else {
+            pFIO->pPDat = pPDat;
+            memset(pPDat, 0, sizeof(ProtoData) * NUM_PROTOCOLS);
+            pPDat->Callsign = pCC->Callsign;
+            pPDat[PROTO_ILINK].Type = PKT_TYPE_AUDIO;
+            pPDat[PROTO_ILINK].bDataValid = TRUE;
+            pPDat[PROTO_ILINK].Data[0] = p->Buf;
+          }
+        }
+
+        if (pPDat != NULL && !(PktHdr.Flags & FILE_FLAG_DATA_PKT)) {
+          pPDat[pCC->Proto].DataLen[0] = 0;
+          pPDat[pCC->Proto].bDataValid = FALSE;
+          pPDat[PROTO_ILINK].DataLen[0] = PktHdr.Len;
+          ConvertProtocol(pPDat, PROTO_ILINK, pCC->Proto, FALSE);
+
+          if ((Len = pPDat[pCC->Proto].DataLen[0]) != 0) {
+            Send2(pCC, pPDat[pCC->Proto].Data[0], Len, FALSE);
+          }
+        }
+      } else {
+        if (!(PktHdr.Flags & FILE_FLAG_DATA_PKT) && !pCC->bSendSSRC) {
+          // It's an audio packet make sure the ssrc is zero, this
+          // client can't deal with a non-zero ssrc !
+          pRTP->ssrc = 0;
+        }
+        Send2(pCC, p->Buf, PktHdr.Len, FALSE);
       }
-      pRTP = (rtp_hdr_t *) p->Buf;
-
-      if(!pCC->bFilePlayer) {
-         if(pCC->Proto != PROTO_ILINK) {
-            ProtoData *pPDat = pFIO->pPDat;
-            int Len;
-
-         // playing for a non-EchoLink client
-            if(pPDat == NULL) {
-               if((pPDat = malloc(sizeof(ProtoData)*NUM_PROTOCOLS)) == NULL) {
-                  LOG_ERROR(("SendAudioFromFile: malloc failed.\n"));
-               }
-               else {
-                  pFIO->pPDat = pPDat;
-                  memset(pPDat,0,sizeof(ProtoData)*NUM_PROTOCOLS);
-                  pPDat->Callsign = pCC->Callsign;
-                  pPDat[PROTO_ILINK].Type = PKT_TYPE_AUDIO;
-                  pPDat[PROTO_ILINK].bDataValid = TRUE;
-                  pPDat[PROTO_ILINK].Data[0] = p->Buf;
-               }
-            }
-
-            if(pPDat != NULL && !(PktHdr.Flags & FILE_FLAG_DATA_PKT)) {
-               pPDat[pCC->Proto].DataLen[0] = 0;
-               pPDat[pCC->Proto].bDataValid = FALSE;
-               pPDat[PROTO_ILINK].DataLen[0] = PktHdr.Len;
-               ConvertProtocol(pPDat,PROTO_ILINK,pCC->Proto,FALSE);
-
-               if((Len = pPDat[pCC->Proto].DataLen[0]) != 0) {
-                  Send2(pCC,pPDat[pCC->Proto].Data[0],Len,FALSE);
-               }
-            }
-         }
-         else {
-            if(!(PktHdr.Flags & FILE_FLAG_DATA_PKT) && !pCC->bSendSSRC) {
-            // It's an audio packet make sure the ssrc is zero, this
-            // client can't deal with a non-zero ssrc !
-               pRTP->ssrc = 0;
-            }
-            Send2(pCC,p->Buf,PktHdr.Len,FALSE);
-         }
+    } else {
+      p->Count = PktHdr.Len;
+      RTP_Data(p, pCS, pCC);
+      if (pCS->bSendStationList) {
+        pCS->bSendStationList = FALSE;
+        SendStationList(pCS);
       }
-      else {
-         p->Count = PktHdr.Len;
-         RTP_Data(p,pCS,pCC);
-         if(pCS->bSendStationList) {
-            pCS->bSendStationList = FALSE;
-            SendStationList(pCS);
-         }
-      }
+    }
 
-      if(!(PktHdr.Flags & FILE_FLAG_RATE_LIMIT)) {
+    if (!(PktHdr.Flags & FILE_FLAG_RATE_LIMIT)) {
       // Don't count this packet against rate limit
-         NumPackets++;
-      }
-      else {
-         pFIO->x++;
-      }
-      Ret = 1;
-   }
+      NumPackets++;
+    } else {
+      pFIO->x++;
+    }
+    Ret = 1;
+  }
 
-   if(Ret == 1) {
-      SetTimeout(p,pFIO->Timeout);
-      pFIO->TimeLastTx = TimeNow;
-      D3PRINTF(("SendAudioFromFile(): Next timeout in %d milliseconds.\n",
-                pFIO->Timeout));
-   }
-   else if(Ret == 2) {
-      EndPoint(p,pFIO->pCC,EVENT_RTP_TO);
-      pFIO->TimeFirstTx.tv_sec = 0;
-      pFIO->x = 0;
-      SetTimeout(p,PlayBackPause*1000);
-      if(ClientTalking == pCC) {
-         ClientTalking = NULL;
-         pCS->bSendStationList = TRUE;
-      }
-      D3PRINTF(("SendAudioFromFile(): Pausing %d seconds.\n",PlayBackPause));
-   }
-   return Ret;
+  if (Ret == 1) {
+    SetTimeout(p, pFIO->Timeout);
+    pFIO->TimeLastTx = TimeNow;
+    D3PRINTF(("SendAudioFromFile(): Next timeout in %d milliseconds.\n",
+              pFIO->Timeout));
+  } else if (Ret == 2) {
+    EndPoint(p, pFIO->pCC, EVENT_RTP_TO);
+    pFIO->TimeFirstTx.tv_sec = 0;
+    pFIO->x = 0;
+    SetTimeout(p, PlayBackPause * 1000);
+    if (ClientTalking == pCC) {
+      ClientTalking = NULL;
+      pCS->bSendStationList = TRUE;
+    }
+    D3PRINTF(("SendAudioFromFile(): Pausing %d seconds.\n", PlayBackPause));
+  }
+  return Ret;
 }
 
+int FilePlayBack(ClientInfo *p) {
+  int TotalDelta = 0;
+  int ThisDelta;
+  int NewDelay;
+  int Packets2Send = 0;
+  ClientFileIO *pFIO = (ClientFileIO *)p->p;
+  ConfClient *pCC = pFIO->pCC;
 
-int FilePlayBack(ClientInfo *p)
-{
-   int TotalDelta = 0;
-   int ThisDelta;
-   int NewDelay;
-   int Packets2Send = 0;
-   ClientFileIO *pFIO = (ClientFileIO *) p->p;
-   ConfClient *pCC = pFIO->pCC;
+  if (pFIO->TimeFirstTx.tv_sec != 0) {
+    TotalDelta = ((TimeNow.tv_sec - pFIO->TimeFirstTx.tv_sec) * 1000) +
+                 ((TimeNow.tv_usec - pFIO->TimeFirstTx.tv_usec) / 1000);
 
-   if(pFIO->TimeFirstTx.tv_sec != 0) {
-      TotalDelta = ((TimeNow.tv_sec - pFIO->TimeFirstTx.tv_sec) * 1000) +
-                   ((TimeNow.tv_usec - pFIO->TimeFirstTx.tv_usec) / 1000);
+    // send one packet every 80 milliseconds
+    // pFIO->x = packets sent so far
+    Packets2Send = (TotalDelta / 80) - pFIO->x;
 
-   // send one packet every 80 milliseconds
-   // pFIO->x = packets sent so far
-      Packets2Send = (TotalDelta / 80) - pFIO->x;
-      
-   // Adjust the next Timeout
-      ThisDelta = ((TimeNow.tv_sec - pFIO->TimeLastTx.tv_sec) * 1000) +
-                  ((TimeNow.tv_usec - pFIO->TimeLastTx.tv_usec) / 1000);
+    // Adjust the next Timeout
+    ThisDelta = ((TimeNow.tv_sec - pFIO->TimeLastTx.tv_sec) * 1000) +
+                ((TimeNow.tv_usec - pFIO->TimeLastTx.tv_usec) / 1000);
 
-      D3PRINTF(("FilePlayBack(): Last delta %d milliseconds.\n",ThisDelta));
+    D3PRINTF(("FilePlayBack(): Last delta %d milliseconds.\n", ThisDelta));
 
-      pFIO->Timeout -= ((ThisDelta - 80)/2);
-      if(pFIO->Timeout <= 0) { 
+    pFIO->Timeout -= ((ThisDelta - 80) / 2);
+    if (pFIO->Timeout <= 0) {
       // Hmmm not keeping up... but we can't make time go backwards!
-         pFIO->Timeout = 1;
-         if(!pFIO->bTooSlowLogged) {
-            pFIO->bTooSlowLogged = TRUE;
-            LOG_ERROR(("FilePlayBack(): Desired timeout reached zero after %d"
-                       " packets.\n",pFIO->x));
-         }
+      pFIO->Timeout = 1;
+      if (!pFIO->bTooSlowLogged) {
+        pFIO->bTooSlowLogged = TRUE;
+        LOG_ERROR(("FilePlayBack(): Desired timeout reached zero after %d"
+                   " packets.\n",
+                   pFIO->x));
       }
-   }
-   else {
-   // First transmission
-      Packets2Send = 1;
-      pFIO->TimeFirstTx = TimeNow;
-   }
+    }
+  } else {
+    // First transmission
+    Packets2Send = 1;
+    pFIO->TimeFirstTx = TimeNow;
+  }
 
-   if(Packets2Send <= 0) {
-      Packets2Send = 0;
-      NewDelay = ((pFIO->x + 1) * 80) - TotalDelta;
-      if(NewDelay <= 0) {
+  if (Packets2Send <= 0) {
+    Packets2Send = 0;
+    NewDelay = ((pFIO->x + 1) * 80) - TotalDelta;
+    if (NewDelay <= 0) {
       // Hmmm again !
-         NewDelay = 1;
+      NewDelay = 1;
+    }
+
+    D3PRINTF(("FilePlayBack(): Too soon to send, waiting %d milliseconds.\n",
+              NewDelay));
+    SetTimeout(p, NewDelay);
+  } else {
+    D3PRINTF(("FilePlayBack(): Send %d packets this time.\n", Packets2Send));
+    if (!SendAudioFromFile(p, pFIO, Packets2Send)) {
+      PlayBackComplete(pCC, "playback complete");
+    }
+  }
+
+  return FALSE;
+}
+
+int FileRecord(ClientInfo *p, ConfClient *pCC, EventType Event) {
+  char *Filename;
+  FilePacketHdr PktHdr;
+  ClientFileIO *pFIO = (ClientFileIO *)pCC->p;
+  int Ret = TRUE;
+
+  switch (Event) {
+  case EVENT_INIT:
+    // Open the file
+    Filename = malloc(strlen(pCC->Callsign) + 6);
+    if (Filename != NULL) {
+      strcpy(Filename, pCC->Callsign);
+      strcat(Filename, ".test");
+      D2PRINTF(("FileRecord(): Opening file \"%s\".\n", Filename));
+      OpenAudioFile(pCC, Filename, MODE_RDWR_BIN);
+      free(Filename);
+      pFIO = (ClientFileIO *)pCC->p;
+      if (pFIO != NULL) {
+        pFIO->bDeleteOnClose = TRUE;
       }
+    }
 
-      D3PRINTF(("FilePlayBack(): Too soon to send, waiting %d milliseconds.\n",
-                NewDelay));
-      SetTimeout(p,NewDelay);
-   }
-   else {
-      D3PRINTF(("FilePlayBack(): Send %d packets this time.\n",Packets2Send));
-      if(!SendAudioFromFile(p,pFIO,Packets2Send)) {
-         PlayBackComplete(pCC,"playback complete");
+    if (!pCC->bFileIOActive) {
+      // file open failed
+      LOG_ERROR(("FileRecord(): fopen for \"%s\" failed, %s", Filename,
+                 Err2String(errno)));
+      Ret = FALSE;
+    }
+    break;
+
+  case EVENT_RTP_RX:
+    if (pFIO->pClient == NULL && p->Buf[0] != ILINK_DATA_PACKET) {
+      if (!pCC->bTalking) {
+        D2PRINTF(("FileRecord(): First RTP data received.\n"));
+        pCC->bTalking = TRUE;
       }
-   }
-   
-   return FALSE;
+      pCC->LastAudioIn = TimeNow;
+      PktHdr.Len = htonl(p->Count);
+      PktHdr.Flags = htonl(FILE_FLAG_RATE_LIMIT);
+
+      if (fwrite(&PktHdr, sizeof(PktHdr), 1, pFIO->fp) != 1 ||
+          fwrite(p->Buf, p->Count, 1, pFIO->fp) != 1) { // Write error
+        LOG_ERROR(("FileRecord(): fwrite failed, %s", Err2String(errno)));
+        PlayBackComplete(pCC, "write error 1");
+      }
+    }
+    break;
+
+  case EVENT_RTP_TO:
+    // timeout, recording is complete, play it back
+    D2PRINTF(("FileRecord(): RTP timeout, rewinding file.\n"));
+    PktHdr.Len = 0;
+    PktHdr.Flags = 0;
+    if (fwrite(&PktHdr, sizeof(PktHdr), 1, pFIO->fp) != 1) {
+      // Write error
+      LOG_ERROR(
+          ("FileRecord(): fwrite of eof header failed, %s", Err2String(errno)));
+      PlayBackComplete(pCC, "write error 2");
+    } else {
+      fseek(pFIO->fp, 0, SEEK_SET);
+      StartPlayback(p, pCC);
+    }
+    break;
+
+  case EVENT_RTCP_TO:
+    // He's gone
+    PlayBackComplete(pCC, "rtcp timeout");
+    break;
+
+  default:
+    break;
+  }
+
+  return Ret;
 }
 
-
-int FileRecord(ClientInfo *p,ConfClient *pCC,EventType Event)
-{
-   char *Filename;
-   FilePacketHdr PktHdr;
-   ClientFileIO *pFIO = (ClientFileIO *) pCC->p;
-   int Ret = TRUE;
-
-   switch(Event) {
-      case EVENT_INIT:
-      // Open the file
-         Filename = malloc(strlen(pCC->Callsign)+6);
-         if(Filename != NULL) {
-            strcpy(Filename,pCC->Callsign);
-            strcat(Filename,".test");
-            D2PRINTF(("FileRecord(): Opening file \"%s\".\n",Filename));
-            OpenAudioFile(pCC,Filename,MODE_RDWR_BIN);
-            free(Filename);
-            pFIO = (ClientFileIO *) pCC->p;
-            if(pFIO != NULL) {
-               pFIO->bDeleteOnClose = TRUE;
-            }
-         }
-         
-         if(!pCC->bFileIOActive) {
-         // file open failed
-            LOG_ERROR(("FileRecord(): fopen for \"%s\" failed, %s",Filename,
-                       Err2String(errno)));
-            Ret = FALSE;
-         }
-         break;
-
-      case EVENT_RTP_RX:
-         if(pFIO->pClient == NULL && p->Buf[0] != ILINK_DATA_PACKET) {
-            if(!pCC->bTalking) {
-               D2PRINTF(("FileRecord(): First RTP data received.\n"));
-               pCC->bTalking = TRUE;
-            }
-            pCC->LastAudioIn = TimeNow;
-            PktHdr.Len = htonl(p->Count);
-            PktHdr.Flags = htonl(FILE_FLAG_RATE_LIMIT);
-
-            if(fwrite(&PktHdr,sizeof(PktHdr),1,pFIO->fp) != 1 ||
-               fwrite(p->Buf,p->Count,1,pFIO->fp) != 1) 
-            {  // Write error
-               LOG_ERROR(("FileRecord(): fwrite failed, %s",Err2String(errno)));
-               PlayBackComplete(pCC,"write error 1");
-            }
-         }
-         break;
-
-      case EVENT_RTP_TO:
-      // timeout, recording is complete, play it back
-         D2PRINTF(("FileRecord(): RTP timeout, rewinding file.\n"));
-         PktHdr.Len = 0;
-         PktHdr.Flags = 0;
-         if(fwrite(&PktHdr,sizeof(PktHdr),1,pFIO->fp) != 1) {
-         // Write error
-            LOG_ERROR(("FileRecord(): fwrite of eof header failed, %s",
-                       Err2String(errno)));
-            PlayBackComplete(pCC,"write error 2");
-         }
-         else {
-            fseek(pFIO->fp,0,SEEK_SET);
-            StartPlayback(p,pCC);
-         }
-         break;
-
-      case EVENT_RTCP_TO:
-      // He's gone
-         PlayBackComplete(pCC,"rtcp timeout");
-         break;
-
-      default:
-         break;
-   }
-
-   return Ret;
+void CmdLevelTest(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  if (!AudioTestConf && FileRecord(p, pCC, EVENT_INIT)) {
+    pCC->bInConf = FALSE;
+    pCC->State = FileRecord;
+    BufPrintf(p, "Your next transmission will be recorded and played back.\r");
+  }
 }
 
-void CmdLevelTest(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   if(!AudioTestConf && FileRecord(p,pCC,EVENT_INIT)) {
-      pCC->bInConf = FALSE;
-      pCC->State = FileRecord;
-      BufPrintf(p,"Your next transmission will be recorded and played back.\r");
-   }
-}
-
-// .connect [-a] [-p <port#>] [-f] [-m] [-n] [-s | -r] [-7] <callign/ip adr> [description]
-// options:
+// .connect [-a] [-p <port#>] [-f] [-m] [-n] [-s | -r] [-7] <callign/ip adr>
+// [description] options:
 //    -a - use ADPCM codec (RTP and Speak Freely protocols only)
 //    -f - full duplex
 //    -m - monitor only
@@ -6095,1100 +5806,1038 @@ void CmdLevelTest(ClientInfo *p,ConfClient *pCC,char *Arg)
 //    -s - use Speak Freely protocol
 //    -u - use uLaw codec (RTP and Speak Freely protocols only)
 //    -7 - use G.726 codec (RTP protocols only)
-void CmdConnect(ClientInfo *p,ConfClient *pCC2,char *Arg)
-{
-   UserInfo OtherConf;
-   ConfClient  Lookup;
-   UserInfo *pUser;
-   struct hostent *pTemp;
-   ConfClient *pCC = NULL;
-   ConfClient *pCC1;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   ConfServer *pHisCS = pCS;
-   ConfServer *pDynamicCS = NULL;
-   ConfServer ConfLookup;
-   int NodeID;
-   int Codecs = 0;
-   int bSpeakFreely = FALSE;
-   int bMonitor = FALSE;
-   int bNailed = FALSE;
-   int bRTP = FALSE;
-   int bADPCM = FALSE;
-   int bULaw = FALSE;
-   int bG726 = FALSE;
-   int bFullDuplex = FALSE;
-   int Port = SF_ReplyPort;
-   int Err;
-   int bEchoLinkNode = FALSE;
-   char *cp = Arg;
-   char *DispCall = NULL;
-   char *Callsign = NULL;
-   char *WhiteSpace = "\t\n ";
-   char Option;
+void CmdConnect(ClientInfo *p, ConfClient *pCC2, char *Arg) {
+  UserInfo OtherConf;
+  ConfClient Lookup;
+  UserInfo *pUser;
+  struct hostent *pTemp;
+  ConfClient *pCC = NULL;
+  ConfClient *pCC1;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  ConfServer *pHisCS = pCS;
+  ConfServer *pDynamicCS = NULL;
+  ConfServer ConfLookup;
+  int NodeID;
+  int Codecs = 0;
+  int bSpeakFreely = FALSE;
+  int bMonitor = FALSE;
+  int bNailed = FALSE;
+  int bRTP = FALSE;
+  int bADPCM = FALSE;
+  int bULaw = FALSE;
+  int bG726 = FALSE;
+  int bFullDuplex = FALSE;
+  int Port = SF_ReplyPort;
+  int Err;
+  int bEchoLinkNode = FALSE;
+  char *cp = Arg;
+  char *DispCall = NULL;
+  char *Callsign = NULL;
+  char *WhiteSpace = "\t\n ";
+  char Option;
 
-   while(*cp == '-') {
-      cp++;
-      switch(Option = *cp++) {
-         case 'p':
-            if(sscanf(cp,"%d",&Port) != 1) {
-               BufPrintf(p,"Error: Invalid port number\r");
-               cp = NULL;
-               Rcode = TBD_ERR_INVALID_ARG;
-               break;
-            }
-            else if(Port & 1) {
-               BufPrintf(p,"Error: Invalid port number, must be even\r");
-               cp = NULL;
-               Rcode = TBD_ERR_INVALID_ARG;
-               break;
-            }
-            else {
-            // Skip past port number
-               while(*cp == ' ') {
-                  cp++;
-               }
+  while (*cp == '-') {
+    cp++;
+    switch (Option = *cp++) {
+    case 'p':
+      if (sscanf(cp, "%d", &Port) != 1) {
+        BufPrintf(p, "Error: Invalid port number\r");
+        cp = NULL;
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      } else if (Port & 1) {
+        BufPrintf(p, "Error: Invalid port number, must be even\r");
+        cp = NULL;
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      } else {
+        // Skip past port number
+        while (*cp == ' ') {
+          cp++;
+        }
 
-               while(*cp && *cp != ' ') {
-                  cp++;
-               }
-            }
-            break;
+        while (*cp && *cp != ' ') {
+          cp++;
+        }
+      }
+      break;
 
-         case 's':
-            bSpeakFreely = TRUE;
-            bRTP = FALSE;
-            break;
+    case 's':
+      bSpeakFreely = TRUE;
+      bRTP = FALSE;
+      break;
 
-         case 'r':
-            bRTP = TRUE;
-            bSpeakFreely = FALSE;
-            break;
+    case 'r':
+      bRTP = TRUE;
+      bSpeakFreely = FALSE;
+      break;
 
-         case 'm':
-            bMonitor = TRUE;
-            break;
+    case 'm':
+      bMonitor = TRUE;
+      break;
 
-         case 'n':
-            bNailed = TRUE;
-            break;
+    case 'n':
+      bNailed = TRUE;
+      break;
 
-#ifdef   LINK_BOX
-         case 'a':
-            bADPCM = TRUE;
-            Codecs++;
-            break;
+#ifdef LINK_BOX
+    case 'a':
+      bADPCM = TRUE;
+      Codecs++;
+      break;
 
-         case 'u':
-            bULaw = TRUE;
-            Codecs++;
-            break;
+    case 'u':
+      bULaw = TRUE;
+      Codecs++;
+      break;
 
-         case '7':
-            bG726 = TRUE;
-            Codecs++;
-            break;
+    case '7':
+      bG726 = TRUE;
+      Codecs++;
+      break;
 #endif
-         case 'f':
-            bFullDuplex = TRUE;
+    case 'f':
+      bFullDuplex = TRUE;
+      break;
+
+    default:
+      BufPrintf(p, "Error: Unknown option '%c'\r", Option);
+      cp = NULL;
+      Rcode = TBD_ERR_INVALID_ARG;
+      break;
+    }
+
+    if (cp == NULL) {
+      break;
+    } else {
+      while (*cp && *cp == ' ') {
+        cp++;
+      }
+    }
+  }
+
+  if (Rcode == 0)
+    do {
+      if (bADPCM && !bSpeakFreely && !bRTP) {
+        // No ADPCM on Echolink
+        BufPrintf(p, "Error: ADPCM codec is not supported by EchoLink.\r");
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      }
+
+      if (bULaw && !bSpeakFreely && !bRTP) {
+        // No uLaw on Echolink
+        BufPrintf(p, "Error: uLaw codec is not supported by EchoLink.\r");
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      }
+
+      if (bG726 && !bRTP) {
+        // No G726 on SF or Echolink
+        BufPrintf(p, "Error: G.726 codec is not supported by EchoLink or "
+                     "Speak Freely.\r");
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      }
+
+      if (Codecs > 1) {
+        BufPrintf(p, "Error: pick just one, uLaw, ADPCM or G.726.\r");
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      }
+
+      if ((Callsign = strtok(cp, WhiteSpace)) == NULL) {
+        BufPrintf(p, "Usage:\r");
+        BufPrintf(p, "connect [-a] [-u] [-7] [-p <port#>] [-m] [-s | -r] [-f] "
+                     "<callign/ip adr> [description]\r");
+        Rcode = TBD_ERR_INVALID_ARG;
+        break;
+      }
+
+      if (bSpeakFreely || bRTP || bG726) {
+        // Look for a "conference" using this port number
+        ConfLookup.AudioPort = Port;
+        if ((pHisCS = avl_find(Conferences, &ConfLookup)) == NULL) {
+          // need to create a dynamic conference
+          Err = CreateConference(Port, piLinkConf, &pDynamicCS);
+          if (Err != 0) {
+            BufPrintf(p, "Error: Couldn't open port (%d)\r", Err);
+            Rcode = TBD_ERR_FILE_OPEN;
             break;
-
-         default:
-            BufPrintf(p,"Error: Unknown option '%c'\r",Option);
-            cp = NULL;
-            Rcode = TBD_ERR_INVALID_ARG;
-            break;
-      }
-      
-      if(cp == NULL) {
-         break;
-      }
-      else {
-         while(*cp && *cp == ' ') {
-            cp++;
-         }
-      }
-   }
-
-   if(Rcode == 0) do {
-      if(bADPCM && !bSpeakFreely && !bRTP) {
-      // No ADPCM on Echolink
-         BufPrintf(p,"Error: ADPCM codec is not supported by EchoLink.\r");
-         Rcode = TBD_ERR_INVALID_ARG;
-         break;
-      }
-
-      if(bULaw && !bSpeakFreely && !bRTP) {
-      // No uLaw on Echolink
-         BufPrintf(p,"Error: uLaw codec is not supported by EchoLink.\r");
-         Rcode = TBD_ERR_INVALID_ARG;
-         break;
-      }
-
-      if(bG726 && !bRTP) {
-      // No G726 on SF or Echolink
-         BufPrintf(p,"Error: G.726 codec is not supported by EchoLink or "
-                   "Speak Freely.\r");
-         Rcode = TBD_ERR_INVALID_ARG;
-         break;
-      }
-
-      if(Codecs > 1) {
-         BufPrintf(p,"Error: pick just one, uLaw, ADPCM or G.726.\r");
-         Rcode = TBD_ERR_INVALID_ARG;
-         break;
-      }
-
-      if((Callsign= strtok(cp,WhiteSpace)) == NULL) {
-         BufPrintf(p,"Usage:\r");
-         BufPrintf(p,"connect [-a] [-u] [-7] [-p <port#>] [-m] [-s | -r] [-f] "
-                   "<callign/ip adr> [description]\r");
-         Rcode = TBD_ERR_INVALID_ARG;
-         break;
-      }
-
-      if(bSpeakFreely || bRTP || bG726) {
-      // Look for a "conference" using this port number
-         ConfLookup.AudioPort = Port;
-         if((pHisCS = avl_find(Conferences,&ConfLookup)) == NULL) {
-         // need to create a dynamic conference
-            Err = CreateConference(Port,piLinkConf,&pDynamicCS);
-            if(Err != 0) {
-               BufPrintf(p,"Error: Couldn't open port (%d)\r",Err);
-               Rcode = TBD_ERR_FILE_OPEN;
-               break;
+          } else {
+            LOG_NORM(("Conference for port %d created\n", Port));
+            pDynamicCS->bDynamicConf = TRUE;
+            if (bSpeakFreely) {
+              pDynamicCS->bSFConf = TRUE;
+            } else {
+              pDynamicCS->bRTPConf = TRUE;
             }
-            else {
-               LOG_NORM(("Conference for port %d created\n",Port));
-               pDynamicCS->bDynamicConf = TRUE;
-               if(bSpeakFreely) {
-                  pDynamicCS->bSFConf = TRUE;
-               }
-               else {
-                  pDynamicCS->bRTPConf = TRUE;
-               }
-               pDynamicCS->pAudio->State = RTP_Handler;
-               pDynamicCS->pControl->State = RTCP_Handler;
-               pDynamicCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
-               pHisCS = pDynamicCS;
-            }
-         }
+            pDynamicCS->pAudio->State = RTP_Handler;
+            pDynamicCS->pControl->State = RTCP_Handler;
+            pDynamicCS->TimeNextSDES = TimeNow.tv_sec + SDES_Interval;
+            pHisCS = pDynamicCS;
+          }
+        }
       }
 
-
-      DispCall = strtok(NULL,"");
+      DispCall = strtok(NULL, "");
       Convert2Upper(Callsign);
       OtherConf.Callsign = Callsign;
-      pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-      while(pCC != NULL) {
-         if(STRCMP(Arg,pCC->Callsign) == 0) {
-            if(pCC->bKicked) {
-               pCC->bKicked = FALSE;
-               pCC->bSWL = FALSE;
-               pCC->bInConf = TRUE;
-               pCC->bConnected = TRUE;
-               pCC->bPermanent = TRUE;
-               IncrementClientCount(pCS,pCC);
-               BufPrintf(p,"Reconnecting \"%s\".\r",Arg);
-            }
-            else if(pCC->bPermanent) {
-               BufPrintf(p,"Already connected to \"%s\".\r",Arg);
-               Rcode = TBD_ERR_CONNECTED;
-               pCC = NULL;
-            }
-            else {
-               pCC->bPermanent = TRUE;
-               BufPrintf(p,"Connection to \"%s\" set to permanent.\r",Arg);
-            }
-            break;
-         }
-         pCC = (ConfClient *) avl_t_next(&avl_trans);
-      }
-      
-      if(Rcode != 0 || pCC != NULL) {
-         break;
+      pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+      while (pCC != NULL) {
+        if (STRCMP(Arg, pCC->Callsign) == 0) {
+          if (pCC->bKicked) {
+            pCC->bKicked = FALSE;
+            pCC->bSWL = FALSE;
+            pCC->bInConf = TRUE;
+            pCC->bConnected = TRUE;
+            pCC->bPermanent = TRUE;
+            IncrementClientCount(pCS, pCC);
+            BufPrintf(p, "Reconnecting \"%s\".\r", Arg);
+          } else if (pCC->bPermanent) {
+            BufPrintf(p, "Already connected to \"%s\".\r", Arg);
+            Rcode = TBD_ERR_CONNECTED;
+            pCC = NULL;
+          } else {
+            pCC->bPermanent = TRUE;
+            BufPrintf(p, "Connection to \"%s\" set to permanent.\r", Arg);
+          }
+          break;
+        }
+        pCC = (ConfClient *)avl_t_next(&avl_trans);
       }
 
-   // Didn't find an existing conference client, create a new one
-      if((pCC = CreateNewConfClient()) == NULL) {
-         break;
+      if (Rcode != 0 || pCC != NULL) {
+        break;
+      }
+
+      // Didn't find an existing conference client, create a new one
+      if ((pCC = CreateNewConfClient()) == NULL) {
+        break;
       }
 
       pCC->pCS = pHisCS;
       pCC->HisAdr.ADDR = INADDR_NONE;
-//    pCC->HisAdr.PORT = htons((uint16_t) Port);
+      //    pCC->HisAdr.PORT = htons((uint16_t) Port);
       pCC->HisAdr.i.sin_family = AF_INET;
       pCC->bNailed = bNailed;
-      if(bSpeakFreely) {
-         pCC->Proto = PROTO_SF;
-      }
-      else if(bRTP) {
-         pCC->Proto = PROTO_RTP;
-      }
-      else {
-         pCC->Proto = PROTO_ILINK;
+      if (bSpeakFreely) {
+        pCC->Proto = PROTO_SF;
+      } else if (bRTP) {
+        pCC->Proto = PROTO_RTP;
+      } else {
+        pCC->Proto = PROTO_ILINK;
       }
 
-      if(bFullDuplex) {
-         pCC->bFullDuplex = TRUE;
+      if (bFullDuplex) {
+        pCC->bFullDuplex = TRUE;
       }
 
-      if(bADPCM) {
-         pCC->CompressionType = RTP_PT_DVI4_8K;
-      }
-      else if(bULaw) {
-         pCC->CompressionType = RTP_PT_PCMU;
-      }
-      else if(bG726) {
-         pCC->CompressionType = RTP_PT_G726;
-      }
-      else {
-         pCC->CompressionType = RTP_PT_GSM;
+      if (bADPCM) {
+        pCC->CompressionType = RTP_PT_DVI4_8K;
+      } else if (bULaw) {
+        pCC->CompressionType = RTP_PT_PCMU;
+      } else if (bG726) {
+        pCC->CompressionType = RTP_PT_G726;
+      } else {
+        pCC->CompressionType = RTP_PT_GSM;
       }
 
-      if(pDynamicCS != NULL) {
-         pDynamicCS->CompressionType = pCC->CompressionType;
+      if (pDynamicCS != NULL) {
+        pDynamicCS->CompressionType = pCC->CompressionType;
       }
       pCC->bMonitor = bMonitor;
 
-      if(DispCall != NULL) {
-         pCC->bCallsignOverride = TRUE;
-         pCC->CallPlus = strdup(DispCall);
-         if((cp = strchr(DispCall,' ')) != NULL) {
-         // truncate string after callsign
-            *cp = 0;
-         }
-         pCC->Callsign = strdup(DispCall);
-      }
-      else {
-         pCC->Callsign = strdup(Callsign);
-         pCC->CallPlus = strdup(Callsign);
+      if (DispCall != NULL) {
+        pCC->bCallsignOverride = TRUE;
+        pCC->CallPlus = strdup(DispCall);
+        if ((cp = strchr(DispCall, ' ')) != NULL) {
+          // truncate string after callsign
+          *cp = 0;
+        }
+        pCC->Callsign = strdup(DispCall);
+      } else {
+        pCC->Callsign = strdup(Callsign);
+        pCC->CallPlus = strdup(Callsign);
       }
       pCC->bPermanent = TRUE;
-      pCC->bInConf = FALSE;   // Not until we get a response from him
+      pCC->bInConf = FALSE; // Not until we get a response from him
 
-      if((pUser = avl_find(UserTree,&OtherConf)) != NULL) {
-         pCC->HisAdr.ADDR = pUser->HisAdr.ADDR; 
-         bEchoLinkNode = TRUE;
-      }
-      else if(strchr(Callsign,'.') == NULL && 
-              sscanf(Callsign,"%d",&NodeID) == 1) 
-      {  // Numeric argument that doesn't contain a '.', 
-         // looking up argument as a EchoLink node ID
-         pUser = (UserInfo *) avl_t_first(&avl_trans,UserTree);
-         while(pUser != NULL) {
-            if(pUser->NodeID == NodeID) {
-               free(pCC->Callsign);
-               free(pCC->CallPlus);
-               pCC->Callsign = strdup(pUser->Callsign);
-               pCC->CallPlus = strdup(pUser->Callsign);
-               pCC->HisAdr.ADDR = pUser->HisAdr.ADDR; 
-               bEchoLinkNode = TRUE;
-               break;
-            }
-            pUser = (UserInfo *) avl_t_next(&avl_trans);
-         }
-      }
-      else {
-      // Didn't find a currently logged in station by that call 
-      // or Node ID, try an IP address
-
-         pCC->HisAdr.ADDR = inet_addr(Callsign); 
-
-         if(pCC->HisAdr.ADDR == INADDR_NONE) {
-         // Try looking up the argument as a hostname
-            pTemp = GetHostByName(Callsign);
-            if(pTemp != NULL) {
-               pCC->HisAdr.ADDR = IP_FROM_HOSTENT(pTemp,0);
-            }
-         }
-      }
-
-      if(pCC->HisAdr.ADDR != INADDR_NONE) {
-         pCC->HisAdr.PORT = pHisCS->AudioPort;
-         Lookup.HisAdr = pCC->HisAdr;
-
-         if((pCC1 = avl_find(pCS->ConfTree,&Lookup)) == NULL) {
-            AddClient2Conf(pHisCS,pCC);
-            SendSDES(pHisCS,pCC);
-            if(bEchoLinkNode) {
-            // K1RFD 1/30/08
-               SendFirewallOpenRequest(pHisCS,pCC);
-            }
-            BufPrintf(p,"Connecting to \"%s\".\r",pCC->Callsign);
-         }
-         else {
-            pCC->HisAdr.ADDR = INADDR_NONE;
-            if(pCC1->bKicked) {
-               pCC1->bKicked = FALSE;
-               pCC1->bSWL = FALSE;
-               pCC1->bInConf = TRUE;
-               pCC1->bPermanent = TRUE;
-               pCC1->bConnected = TRUE;
-               IncrementClientCount(pCS,pCC);
-               BufPrintf(p,"Reconnecting \"%s\".\r",pCC->Callsign);
-            }
-            else if(pCC1->bPermanent) {
-               BufPrintf(p,"Already connected to \"%s\".\r",pCC->Callsign);
-               Rcode = TBD_ERR_CONNECTED;
-            }
-            else {
-               pCC1->bPermanent = TRUE;
-               BufPrintf(p,"Connection to \"%s\" set to permanent.\r",
-                         pCC->Callsign);
-            }
-         }
-      }
-      else {
-         BufPrintf(p,"Station \"%s\" not found.\r",Callsign);
-         Rcode = TBD_STATION_NOT_FOUND;
-      }
-
-      if(pCC->HisAdr.ADDR == INADDR_NONE) {
-         free(pCC->Callsign);
-         free(pCC->CallPlus);
-         free(pCC);
-      }
-   } while(FALSE);
-
-   if(pDynamicCS != NULL) {
-      if(Rcode != 0) {
-      // Clean up dynamically created conference on failure
-         DeleteConf(pDynamicCS);
-      }
-   }
-}
-
-void CmdDisconnect(ClientInfo *p,ConfClient *pCC1,char *Arg)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = (ConfServer *) p->p;
-   int bStationFound = FALSE;
-   char *Call = Arg;
-   int bAllStations = FALSE;
-   
-   if(STRCMP(Arg,"all") == 0) {
-      bAllStations = TRUE;
-   }
-   else if(STRCMP(Arg,"last") == 0) {
-   // Find the last station that connected
-      int LargestSN = 0;
-      ConfClient *pCC1 = NULL;
-
-      pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-      while(pCC != NULL) {
-         if(pCC->SN > LargestSN) {
-            LargestSN = pCC->SN;
-            pCC1 = pCC;
-         }
-         pCC = (ConfClient *) avl_t_next(&avl_trans);
-      }
-
-      if(pCC1 != NULL) {
-      // Set arg to the callsign of the selected station
-         Call = pCC1->Callsign;
-      }
-   }
-
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(STRCMP(Call,pCC->Callsign) == 0 || 
-         (bAllStations && !pCC->bNailed) ||
-         (*Arg == '.' && pCC == ClientTalking))
-      {
-         bStationFound = TRUE;
-         LOG_NORM(("%s disconnected by %s\n",CallLog(pCC),pCC1->Callsign));
-         DisconnectCC(p,pCC,"Bye bye !");
-
-         pCS->bSendStationList = TRUE;
-         if(StationDisconnected != NULL) {
-            free(StationDisconnected);
-         }
-         StationDisconnected = strdup(pCC->Callsign);
-
-         if(!bAllStations) {
+      if ((pUser = avl_find(UserTree, &OtherConf)) != NULL) {
+        pCC->HisAdr.ADDR = pUser->HisAdr.ADDR;
+        bEchoLinkNode = TRUE;
+      } else if (strchr(Callsign, '.') == NULL &&
+                 sscanf(Callsign, "%d", &NodeID) ==
+                     1) { // Numeric argument that doesn't contain a '.',
+        // looking up argument as a EchoLink node ID
+        pUser = (UserInfo *)avl_t_first(&avl_trans, UserTree);
+        while (pUser != NULL) {
+          if (pUser->NodeID == NodeID) {
+            free(pCC->Callsign);
+            free(pCC->CallPlus);
+            pCC->Callsign = strdup(pUser->Callsign);
+            pCC->CallPlus = strdup(pUser->Callsign);
+            pCC->HisAdr.ADDR = pUser->HisAdr.ADDR;
+            bEchoLinkNode = TRUE;
             break;
-         }
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+          }
+          pUser = (UserInfo *)avl_t_next(&avl_trans);
+        }
+      } else {
+        // Didn't find a currently logged in station by that call
+        // or Node ID, try an IP address
 
-// We clobbered the buffer, reinitialize it for our response
-   p->Count = 0;  // init for BufPrintf
-   BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
+        pCC->HisAdr.ADDR = inet_addr(Callsign);
 
-   if(!bStationFound) {
-      if(*Arg == '.') {
-         BufPrintf(p,"No one is talking\r");
+        if (pCC->HisAdr.ADDR == INADDR_NONE) {
+          // Try looking up the argument as a hostname
+          pTemp = GetHostByName(Callsign);
+          if (pTemp != NULL) {
+            pCC->HisAdr.ADDR = IP_FROM_HOSTENT(pTemp, 0);
+          }
+        }
       }
-      else if(bAllStations) {
-         BufPrintf(p,"No stations found\r");
+
+      if (pCC->HisAdr.ADDR != INADDR_NONE) {
+        pCC->HisAdr.PORT = pHisCS->AudioPort;
+        Lookup.HisAdr = pCC->HisAdr;
+
+        if ((pCC1 = avl_find(pCS->ConfTree, &Lookup)) == NULL) {
+          AddClient2Conf(pHisCS, pCC);
+          SendSDES(pHisCS, pCC);
+          if (bEchoLinkNode) {
+            // K1RFD 1/30/08
+            SendFirewallOpenRequest(pHisCS, pCC);
+          }
+          BufPrintf(p, "Connecting to \"%s\".\r", pCC->Callsign);
+        } else {
+          pCC->HisAdr.ADDR = INADDR_NONE;
+          if (pCC1->bKicked) {
+            pCC1->bKicked = FALSE;
+            pCC1->bSWL = FALSE;
+            pCC1->bInConf = TRUE;
+            pCC1->bPermanent = TRUE;
+            pCC1->bConnected = TRUE;
+            IncrementClientCount(pCS, pCC);
+            BufPrintf(p, "Reconnecting \"%s\".\r", pCC->Callsign);
+          } else if (pCC1->bPermanent) {
+            BufPrintf(p, "Already connected to \"%s\".\r", pCC->Callsign);
+            Rcode = TBD_ERR_CONNECTED;
+          } else {
+            pCC1->bPermanent = TRUE;
+            BufPrintf(p, "Connection to \"%s\" set to permanent.\r",
+                      pCC->Callsign);
+          }
+        }
+      } else {
+        BufPrintf(p, "Station \"%s\" not found.\r", Callsign);
+        Rcode = TBD_STATION_NOT_FOUND;
       }
-      else {
-         BufPrintf(p,"%s not found\r",Arg);
+
+      if (pCC->HisAdr.ADDR == INADDR_NONE) {
+        free(pCC->Callsign);
+        free(pCC->CallPlus);
+        free(pCC);
       }
-      Rcode = TBD_STATION_NOT_FOUND;
-   }
-   else if(bAllStations) {
-      BufPrintf(p,"All stations disconnected\r");
-   }
-   else {
-      BufPrintf(p,"%s disconnected\r",StationDisconnected);
-   }
+    } while (FALSE);
+
+  if (pDynamicCS != NULL) {
+    if (Rcode != 0) {
+      // Clean up dynamically created conference on failure
+      DeleteConf(pDynamicCS);
+    }
+  }
 }
 
-void CmdInfo(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   char *Temp = strdup(ConnectedStatus);
-   UpdateConnectedStatus();
-   if(*Arg) {
-      if(ConferenceQth != NULL) {
-         free(ConferenceQth);
+void CmdDisconnect(ClientInfo *p, ConfClient *pCC1, char *Arg) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = (ConfServer *)p->p;
+  int bStationFound = FALSE;
+  char *Call = Arg;
+  int bAllStations = FALSE;
+
+  if (STRCMP(Arg, "all") == 0) {
+    bAllStations = TRUE;
+  } else if (STRCMP(Arg, "last") == 0) {
+    // Find the last station that connected
+    int LargestSN = 0;
+    ConfClient *pCC1 = NULL;
+
+    pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+    while (pCC != NULL) {
+      if (pCC->SN > LargestSN) {
+        LargestSN = pCC->SN;
+        pCC1 = pCC;
       }
-      ConferenceQth = strdup(Arg);
-   }
+      pCC = (ConfClient *)avl_t_next(&avl_trans);
+    }
 
-   if(LoginInterval > 0 && (*Arg || strcmp(ConnectedStatus,Temp) != 0)) {
-   // Send update to directory server
-      NextLoginTime = TimeNow.tv_sec + LoginInterval;
-      ServerRequest(SERV_REQ_LOGIN,0,NULL);
-   }
-   free(Temp);
+    if (pCC1 != NULL) {
+      // Set arg to the callsign of the selected station
+      Call = pCC1->Callsign;
+    }
+  }
 
-   BufPrintf(p,"Current location string: %s\r",ConferenceQth);
-   if(ShowStatusInInfo && ConnectedStatus[0] != 0) {
-      BufPrintf(p,"Currently displaying: %s\r",ConnectedStatus);
-   }
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (STRCMP(Call, pCC->Callsign) == 0 || (bAllStations && !pCC->bNailed) ||
+        (*Arg == '.' && pCC == ClientTalking)) {
+      bStationFound = TRUE;
+      LOG_NORM(("%s disconnected by %s\n", CallLog(pCC), pCC1->Callsign));
+      DisconnectCC(p, pCC, "Bye bye !");
+
+      pCS->bSendStationList = TRUE;
+      if (StationDisconnected != NULL) {
+        free(StationDisconnected);
+      }
+      StationDisconnected = strdup(pCC->Callsign);
+
+      if (!bAllStations) {
+        break;
+      }
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
+
+  // We clobbered the buffer, reinitialize it for our response
+  p->Count = 0; // init for BufPrintf
+  BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+
+  if (!bStationFound) {
+    if (*Arg == '.') {
+      BufPrintf(p, "No one is talking\r");
+    } else if (bAllStations) {
+      BufPrintf(p, "No stations found\r");
+    } else {
+      BufPrintf(p, "%s not found\r", Arg);
+    }
+    Rcode = TBD_STATION_NOT_FOUND;
+  } else if (bAllStations) {
+    BufPrintf(p, "All stations disconnected\r");
+  } else {
+    BufPrintf(p, "%s disconnected\r", StationDisconnected);
+  }
 }
 
-void CmdPauseTime(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   if(*Arg) {  
-      if(sscanf(Arg,"%d",&PauseTime) != 1) {
-         BufPrintf(p,"Error: \"%s\" is not a number.\r",Arg);
-         Rcode = TBD_ERR_INVALID_ARG;
-      }
-   }
-   BufPrintf(p,"The minimum pause time is %d milliseconds\r",PauseTime);
+void CmdInfo(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  char *Temp = strdup(ConnectedStatus);
+  UpdateConnectedStatus();
+  if (*Arg) {
+    if (ConferenceQth != NULL) {
+      free(ConferenceQth);
+    }
+    ConferenceQth = strdup(Arg);
+  }
+
+  if (LoginInterval > 0 && (*Arg || strcmp(ConnectedStatus, Temp) != 0)) {
+    // Send update to directory server
+    NextLoginTime = TimeNow.tv_sec + LoginInterval;
+    ServerRequest(SERV_REQ_LOGIN, 0, NULL);
+  }
+  free(Temp);
+
+  BufPrintf(p, "Current location string: %s\r", ConferenceQth);
+  if (ShowStatusInInfo && ConnectedStatus[0] != 0) {
+    BufPrintf(p, "Currently displaying: %s\r", ConnectedStatus);
+  }
 }
 
-void CmdBelchfilter(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   if(*Arg) {  
-      if(sscanf(Arg,"%d",&BelchTime) != 1) {
-         BufPrintf(p,"Error: \"%s\" is not a number.\r",Arg);
-      }
-   }
-   BufPrintf(p,"The belchfilter is current set to %d milliseconds\r",BelchTime);
+void CmdPauseTime(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  if (*Arg) {
+    if (sscanf(Arg, "%d", &PauseTime) != 1) {
+      BufPrintf(p, "Error: \"%s\" is not a number.\r", Arg);
+      Rcode = TBD_ERR_INVALID_ARG;
+    }
+  }
+  BufPrintf(p, "The minimum pause time is %d milliseconds\r", PauseTime);
+}
+
+void CmdBelchfilter(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  if (*Arg) {
+    if (sscanf(Arg, "%d", &BelchTime) != 1) {
+      BufPrintf(p, "Error: \"%s\" is not a number.\r", Arg);
+    }
+  }
+  BufPrintf(p, "The belchfilter is current set to %d milliseconds\r",
+            BelchTime);
 }
 
 // Busy [on] [off] [status]
-void CmdBusy(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   int bBusyStateChanged = FALSE;
+void CmdBusy(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  int bBusyStateChanged = FALSE;
 
-   if(*Arg) {  
-      if(STRCMP(Arg,"on") == 0) {
-         bBusyStateChanged = !PullerStatusBusy;
-         bConferenceBusy = TRUE;
-         PullerStatusBusy = TRUE;
-      }
-      else if(STRCMP(Arg,"off") == 0) {
-         bBusyStateChanged = PullerStatusBusy;
-         bConferenceBusy = FALSE;
-         PullerStatusBusy = FALSE;
-      }
-      else if(STRCMP(Arg,"status") == 0) {
-         bBusyStateChanged = !PullerStatusBusy;
-         bConferenceBusy = FALSE;
-         PullerStatusBusy = TRUE;
-      }
-      else {
-         BufPrintf(p,"Error: Invalid argument \"%s\"\r",Arg);
-         BufPrintf(p,"Usage: Busy [on] [off] [status]\r");
-      }
-   }
-   if(bBusyStateChanged) {
-      if(LoginInterval > 0) {
-         NextAVRSTime = TimeNow.tv_sec;   // Force an AVRS update
-         NextLoginTime = TimeNow.tv_sec + LoginInterval;
-         ServerRequest(SERV_REQ_LOGIN,0,NULL);
-      }
-   }
-   if(bConferenceBusy != PullerStatusBusy) {
-      BufPrintf(p,"The indicated conference state is %s.\r",
-                PullerStatusBusy ? "busy" : "available");
-   }
-   else {
-      BufPrintf(p,"The conference is %s.\r",
-                PullerStatusBusy ? "busy" : "available");
-   }
+  if (*Arg) {
+    if (STRCMP(Arg, "on") == 0) {
+      bBusyStateChanged = !PullerStatusBusy;
+      bConferenceBusy = TRUE;
+      PullerStatusBusy = TRUE;
+    } else if (STRCMP(Arg, "off") == 0) {
+      bBusyStateChanged = PullerStatusBusy;
+      bConferenceBusy = FALSE;
+      PullerStatusBusy = FALSE;
+    } else if (STRCMP(Arg, "status") == 0) {
+      bBusyStateChanged = !PullerStatusBusy;
+      bConferenceBusy = FALSE;
+      PullerStatusBusy = TRUE;
+    } else {
+      BufPrintf(p, "Error: Invalid argument \"%s\"\r", Arg);
+      BufPrintf(p, "Usage: Busy [on] [off] [status]\r");
+    }
+  }
+  if (bBusyStateChanged) {
+    if (LoginInterval > 0) {
+      NextAVRSTime = TimeNow.tv_sec; // Force an AVRS update
+      NextLoginTime = TimeNow.tv_sec + LoginInterval;
+      ServerRequest(SERV_REQ_LOGIN, 0, NULL);
+    }
+  }
+  if (bConferenceBusy != PullerStatusBusy) {
+    BufPrintf(p, "The indicated conference state is %s.\r",
+              PullerStatusBusy ? "busy" : "available");
+  } else {
+    BufPrintf(p, "The conference is %s.\r",
+              PullerStatusBusy ? "busy" : "available");
+  }
 }
 
-void CmdChat(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   if(*Arg) {  
-      if(STRCMP(Arg,"on") == 0) {
-         bCmdLineChatMode = TRUE;
-      }
-      else if(STRCMP(Arg,"off") == 0) {
-         bCmdLineChatMode = FALSE;
-      }
-      else {
-         BufPrintf(p,"Error: Invalid argument \"%s\"\r",Arg);
-         BufPrintf(p,"Usage: Chat [on] [off]\r");
-      }
-   }
-   BufPrintf(p,"Chat mode is %s.\r",bCmdLineChatMode ? "on" : "off");
+void CmdChat(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  if (*Arg) {
+    if (STRCMP(Arg, "on") == 0) {
+      bCmdLineChatMode = TRUE;
+    } else if (STRCMP(Arg, "off") == 0) {
+      bCmdLineChatMode = FALSE;
+    } else {
+      BufPrintf(p, "Error: Invalid argument \"%s\"\r", Arg);
+      BufPrintf(p, "Usage: Chat [on] [off]\r");
+    }
+  }
+  BufPrintf(p, "Chat mode is %s.\r", bCmdLineChatMode ? "on" : "off");
 }
 
-void CmdCrash(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   DumpMe();
-}
+void CmdCrash(ClientInfo *p, ConfClient *pCC, char *Arg) { DumpMe(); }
 
+void CmdHelpNoDot(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  CmdHelp(p, pCC, Arg);
 
-void CmdHelpNoDot(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   CmdHelp(p,pCC,Arg);
-
-   BufPrintf(p,"PLEASE NOTE: All commands MUST start with a PERIOD or DOT.\r");
-   BufPrintf(p,"The HELP command you just entered is the only exception.\r");
+  BufPrintf(p, "PLEASE NOTE: All commands MUST start with a PERIOD or DOT.\r");
+  BufPrintf(p, "The HELP command you just entered is the only exception.\r");
 }
 
 // CmdLine
 // 0 = command doesn't match
 // 1 = command matches
 // 2 = exact command match
-int MatchCmd(const char *CmdLine, const char *Command)
-{
-   while(*CmdLine == ' ') {
-      CmdLine++;
-   }
+int MatchCmd(const char *CmdLine, const char *Command) {
+  while (*CmdLine == ' ') {
+    CmdLine++;
+  }
 
-   if(!*CmdLine) {
-      return 0;
-   }
+  if (!*CmdLine) {
+    return 0;
+  }
 
-   while(*CmdLine && *CmdLine != ' ' && *CmdLine != '\r' && *CmdLine != '\n') {
-      if(tolower(*CmdLine) != tolower(*Command)) {
-         return FALSE;
-      }
-      CmdLine++;
-      Command++;
-   }
-   if(*Command == 0) {
-   // Exact match
-      return 2;
-   }
-   return 1;
+  while (*CmdLine && *CmdLine != ' ' && *CmdLine != '\r' && *CmdLine != '\n') {
+    if (tolower(*CmdLine) != tolower(*Command)) {
+      return FALSE;
+    }
+    CmdLine++;
+    Command++;
+  }
+  if (*Command == 0) {
+    // Exact match
+    return 2;
+  }
+  return 1;
 }
 
 struct COMMAND_TABLE {
-   char *CmdString;
-   char *HelpString;
-   void (*CmdHandler)(ClientInfo *p,ConfClient *pCC,char *Arg);
-   int   Flags;
-      #define  CMD_FLAG_NOLIST      1  // suppress listing in help commands
-      #define  CMD_FLAG_ADMIN       2  // commands available to admins only
-      #define  CMD_FLAG_NEED_DISK   4  // commands that access the disk
-      #define  CMD_FLAG_SYSOP       8  // commands available to sysops & admins
-      #define  CMD_FLAG_LURK     0x10  // lurking command
-      #define  CMD_FLAG_NOSCRIPT 0x20  // command not available to scripting
-      #define  CMD_FLAG_SCRIPT   0x40  // command only available to scripting
-      #define  CMD_FLAG_RFONLY   0x80  // command only available to rf users
+  char *CmdString;
+  char *HelpString;
+  void (*CmdHandler)(ClientInfo *p, ConfClient *pCC, char *Arg);
+  int Flags;
+#define CMD_FLAG_NOLIST 1      // suppress listing in help commands
+#define CMD_FLAG_ADMIN 2       // commands available to admins only
+#define CMD_FLAG_NEED_DISK 4   // commands that access the disk
+#define CMD_FLAG_SYSOP 8       // commands available to sysops & admins
+#define CMD_FLAG_LURK 0x10     // lurking command
+#define CMD_FLAG_NOSCRIPT 0x20 // command not available to scripting
+#define CMD_FLAG_SCRIPT 0x40   // command only available to scripting
+#define CMD_FLAG_RFONLY 0x80   // command only available to rf users
 };
 
-#define CMD_ADMIN_DISK  (CMD_FLAG_ADMIN | CMD_FLAG_NEED_DISK)
+#define CMD_ADMIN_DISK (CMD_FLAG_ADMIN | CMD_FLAG_NEED_DISK)
 
 struct COMMAND_TABLE commandtable[] = {
-   { "about", "Show information about specified station", CmdAbout, 0},
-   { "admin", "", CmdAdmin, CMD_FLAG_NOLIST},
-   { "admins", "List logged in admins", CmdAdmins, CMD_FLAG_SYSOP},
-   { "allow", "Allow a user to use the conference", CmdAllow, CMD_FLAG_ADMIN},
-   { "ban", "Ban a user from the conference", CmdBan, CMD_FLAG_ADMIN},
-   { "belchfilter", "Set minimum TX time for recognition", CmdBelchfilter, 
-      CMD_FLAG_SYSOP},
-   { "busy", "List conference as busy", CmdBusy, CMD_FLAG_SYSOP},
-   { "chat", "enable or disable chat traffic", CmdChat, CMD_FLAG_SCRIPT},
-   { "crash", "", CmdCrash, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST },
-   { "connect", "Connect to another conference", CmdConnect, CMD_FLAG_SYSOP},
-   { "debug", "", CmdDebug, CMD_FLAG_NOLIST },
-#ifdef   LINK_BOX
-   { "dtmfdecode", "", CmdDtmfDecode, CMD_FLAG_NOLIST },
+    {"about", "Show information about specified station", CmdAbout, 0},
+    {"admin", "", CmdAdmin, CMD_FLAG_NOLIST},
+    {"admins", "List logged in admins", CmdAdmins, CMD_FLAG_SYSOP},
+    {"allow", "Allow a user to use the conference", CmdAllow, CMD_FLAG_ADMIN},
+    {"ban", "Ban a user from the conference", CmdBan, CMD_FLAG_ADMIN},
+    {"belchfilter", "Set minimum TX time for recognition", CmdBelchfilter,
+     CMD_FLAG_SYSOP},
+    {"busy", "List conference as busy", CmdBusy, CMD_FLAG_SYSOP},
+    {"chat", "enable or disable chat traffic", CmdChat, CMD_FLAG_SCRIPT},
+    {"crash", "", CmdCrash, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"connect", "Connect to another conference", CmdConnect, CMD_FLAG_SYSOP},
+    {"debug", "", CmdDebug, CMD_FLAG_NOLIST},
+#ifdef LINK_BOX
+    {"dtmfdecode", "", CmdDtmfDecode, CMD_FLAG_NOLIST},
 #endif
-   { "dns", "DNS [refresh] [list]", CmdDNS, CMD_FLAG_ADMIN},
-   { "disconnect", "Disconnect from another conference", CmdDisconnect, 
-      CMD_FLAG_SYSOP},
-   { "delurk", "Leave monitor mode", CmdDelurk, CMD_FLAG_LURK },
-   { "help", "", CmdHelp, CMD_FLAG_NOLIST},
-   { "elp", "", CmdHelpNoDot, CMD_FLAG_NOLIST},
-#ifdef   LINK_BOX
-   { "id", "", CmdForceID, CMD_FLAG_NOLIST | CMD_FLAG_ADMIN},
-   { "frequency", "set RF ports operating parameters", CmdFrequency, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"dns", "DNS [refresh] [list]", CmdDNS, CMD_FLAG_ADMIN},
+    {"disconnect", "Disconnect from another conference", CmdDisconnect,
+     CMD_FLAG_SYSOP},
+    {"delurk", "Leave monitor mode", CmdDelurk, CMD_FLAG_LURK},
+    {"help", "", CmdHelp, CMD_FLAG_NOLIST},
+    {"elp", "", CmdHelpNoDot, CMD_FLAG_NOLIST},
+#ifdef LINK_BOX
+    {"id", "", CmdForceID, CMD_FLAG_NOLIST | CMD_FLAG_ADMIN},
+    {"frequency", "set RF ports operating parameters", CmdFrequency,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
 #endif
-   { "info", "Set directory server location string", CmdInfo, CMD_FLAG_ADMIN},
-   { "kick", "kick a user off conference", CmdKick, CMD_FLAG_ADMIN},
-   { "list", "List available prerecorded nets and bulletins", CmdList, 
-      CMD_FLAG_NEED_DISK },
-#ifdef   LINK_BOX
-   { "link", "Link on port to another", CmdLink, CMD_FLAG_NOLIST | CMD_FLAG_ADMIN},
+    {"info", "Set directory server location string", CmdInfo, CMD_FLAG_ADMIN},
+    {"kick", "kick a user off conference", CmdKick, CMD_FLAG_ADMIN},
+    {"list", "List available prerecorded nets and bulletins", CmdList,
+     CMD_FLAG_NEED_DISK},
+#ifdef LINK_BOX
+    {"link", "Link on port to another", CmdLink,
+     CMD_FLAG_NOLIST | CMD_FLAG_ADMIN},
 #endif
-   { "lookup","Lookup a user by Callsign and display Node,Qth", CmdLookUp,0},
-   { "lurk", "Enter monitor mode", CmdLurk, CMD_FLAG_LURK },
-   { "lurkers", "", CmdLurkers, CMD_FLAG_NOLIST},
-   { "message", "send text message to all users", CmdMessage, 
-      CMD_FLAG_SYSOP | CMD_FLAG_SCRIPT},
-   { "monitor", "don't send to specified station", CmdMonitor, CMD_FLAG_SYSOP},
-   { "mute", "put a user into receive only mode", CmdMute, CMD_FLAG_SYSOP},
-#ifdef   LINK_BOX
-   { "script", "", CmdScript, CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
+    {"lookup", "Lookup a user by Callsign and display Node,Qth", CmdLookUp, 0},
+    {"lurk", "Enter monitor mode", CmdLurk, CMD_FLAG_LURK},
+    {"lurkers", "", CmdLurkers, CMD_FLAG_NOLIST},
+    {"message", "send text message to all users", CmdMessage,
+     CMD_FLAG_SYSOP | CMD_FLAG_SCRIPT},
+    {"monitor", "don't send to specified station", CmdMonitor, CMD_FLAG_SYSOP},
+    {"mute", "put a user into receive only mode", CmdMute, CMD_FLAG_SYSOP},
+#ifdef LINK_BOX
+    {"script", "", CmdScript, CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
 #endif
-   { "sysop", "", CmdSysop, CMD_FLAG_NOLIST},
-   { "pausetime", "Set minimum pause time", CmdPauseTime, CMD_FLAG_SYSOP},
+    {"sysop", "", CmdSysop, CMD_FLAG_NOLIST},
+    {"pausetime", "Set minimum pause time", CmdPauseTime, CMD_FLAG_SYSOP},
 
-#ifdef   LINK_BOX
-   { "pcm", "raw pcm record/playback for debuggging", CmdPCM, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+#ifdef LINK_BOX
+    {"pcm", "raw pcm record/playback for debuggging", CmdPCM,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
 #endif
 
-   { "play", "play are prerecorded net or bulletin", CmdPlay, 
-      CMD_FLAG_NEED_DISK | CMD_FLAG_NOSCRIPT},
-   { "play4", "play file for specified user(s)", CmdPlayFor, 
-      CMD_FLAG_SYSOP | CMD_FLAG_NEED_DISK },
-#ifdef   LINK_BOX
-   { "port", "",CmdSetPort, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST },
+    {"play", "play are prerecorded net or bulletin", CmdPlay,
+     CMD_FLAG_NEED_DISK | CMD_FLAG_NOSCRIPT},
+    {"play4", "play file for specified user(s)", CmdPlayFor,
+     CMD_FLAG_SYSOP | CMD_FLAG_NEED_DISK},
+#ifdef LINK_BOX
+    {"port", "", CmdSetPort, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
 #endif
-   { "quickexit", "", CmdQuit, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST },
-   { "quote", "send a command to linked conferences", CmdQuote, CMD_FLAG_SYSOP},
-   { "record", "record traffic for later playback", CmdRecord, CMD_ADMIN_DISK},
-   { "refresh", "refresh station list", CmdRefresh, CMD_FLAG_ADMIN},
-   { "rehash", "re-read the configuration file", CmdRehash, CMD_FLAG_ADMIN},
-#ifdef   LINK_BOX
-   { "txoffset", "set transmitter offset", CmdTxOffset, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "txpower", "set transmitter power", CmdTxPower, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "rxfrequency", "set ports receive frequency", CmdRxFrequency, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "rxtone", "set CTCSS or DCS decoder tone", CmdRxTone, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "rxlevel", "display receiver levels", CmdRxLevel, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"quickexit", "", CmdQuit, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"quote", "send a command to linked conferences", CmdQuote, CMD_FLAG_SYSOP},
+    {"record", "record traffic for later playback", CmdRecord, CMD_ADMIN_DISK},
+    {"refresh", "refresh station list", CmdRefresh, CMD_FLAG_ADMIN},
+    {"rehash", "re-read the configuration file", CmdRehash, CMD_FLAG_ADMIN},
+#ifdef LINK_BOX
+    {"txoffset", "set transmitter offset", CmdTxOffset,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"txpower", "set transmitter power", CmdTxPower,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"rxfrequency", "set ports receive frequency", CmdRxFrequency,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"rxtone", "set CTCSS or DCS decoder tone", CmdRxTone,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"rxlevel", "display receiver levels", CmdRxLevel,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
 #endif
-   { "set", "set a configuration variable", CmdSet, CMD_FLAG_ADMIN},
-   { "showip", "show IP address of current users", CmdShowIP, CMD_FLAG_ADMIN },
-   { "shutdown", "", CmdShutdown, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-#ifdef   LINK_BOX
-   { "shutup", "kill queued announcements", CmdShutup, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "say", "Speak a phrase to RF port", CmdSay, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "sayresult", "Say results of previous command", CmdSayResult, 
-      CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
-   { "saystatus", "Announce system status", CmdSayStatus, 
-      CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
-   { "sendbeacon", "send AX25 beacon", CmdSendAx25Beacon, 
-      CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
+    {"set", "set a configuration variable", CmdSet, CMD_FLAG_ADMIN},
+    {"showip", "show IP address of current users", CmdShowIP, CMD_FLAG_ADMIN},
+    {"shutdown", "", CmdShutdown, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+#ifdef LINK_BOX
+    {"shutup", "kill queued announcements", CmdShutup,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"say", "Speak a phrase to RF port", CmdSay,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"sayresult", "Say results of previous command", CmdSayResult,
+     CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
+    {"saystatus", "Announce system status", CmdSayStatus,
+     CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
+    {"sendbeacon", "send AX25 beacon", CmdSendAx25Beacon,
+     CMD_FLAG_RFONLY | CMD_FLAG_NOLIST},
 #endif
-   { "stats", "Display statistics", CmdStats, 0},
-#ifdef   LINK_BOX
-   { "sweep", "Generate test tone", CmdSweep, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"stats", "Display statistics", CmdStats, 0},
+#ifdef LINK_BOX
+    {"sweep", "Generate test tone", CmdSweep, CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
 #endif
-   { "stop", "end playback of recorded bulletin", CmdStop, 
-      CMD_FLAG_NEED_DISK | CMD_FLAG_NOSCRIPT},
-#ifdef   LINK_BOX
-   { "tonegen", "Generate telemeter tones on for current port", CmdToneGen, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
-   { "txtone", "set CTCSS or DCS encode tone", CmdTxTone, 
-      CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"stop", "end playback of recorded bulletin", CmdStop,
+     CMD_FLAG_NEED_DISK | CMD_FLAG_NOSCRIPT},
+#ifdef LINK_BOX
+    {"tonegen", "Generate telemeter tones on for current port", CmdToneGen,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
+    {"txtone", "set CTCSS or DCS encode tone", CmdTxTone,
+     CMD_FLAG_ADMIN | CMD_FLAG_NOLIST},
 #endif
-   { "test", "Record and playback test transmission", CmdLevelTest, 
-      CMD_FLAG_NEED_DISK | CMD_FLAG_NOSCRIPT},
-   { "unmute", "restore a user to transceive mode", CmdUnMute, CMD_FLAG_SYSOP},
-   { "users", "show user list", CmdUsers, CMD_FLAG_SYSOP},
+    {"test", "Record and playback test transmission", CmdLevelTest,
+     CMD_FLAG_NEED_DISK | CMD_FLAG_NOSCRIPT},
+    {"unmute", "restore a user to transceive mode", CmdUnMute, CMD_FLAG_SYSOP},
+    {"users", "show user list", CmdUsers, CMD_FLAG_SYSOP},
 
-#ifdef   LINK_BOX
-   { "unlink", "Unlink ports", CmdUnLink, CMD_FLAG_NOLIST | CMD_FLAG_ADMIN},
+#ifdef LINK_BOX
+    {"unlink", "Unlink ports", CmdUnLink, CMD_FLAG_NOLIST | CMD_FLAG_ADMIN},
 #endif
-   { "uptime", "Display system uptime", CmdUpTime, 0},
-   { "version", "Display version info", CmdVersion, 0},
-   { "xyzzy", "", CmdXyzzy, CMD_FLAG_NOLIST},
-   { "?", "", CmdHelp, CMD_FLAG_NOLIST},
-   { NULL}
-};
+    {"uptime", "Display system uptime", CmdUpTime, 0},
+    {"version", "Display version info", CmdVersion, 0},
+    {"xyzzy", "", CmdXyzzy, CMD_FLAG_NOLIST},
+    {"?", "", CmdHelp, CMD_FLAG_NOLIST},
+    {NULL}};
 
-void CmdHelp(ClientInfo *p,ConfClient *pCC,char *Arg)
-{
-   struct COMMAND_TABLE *pTbl = commandtable;
+void CmdHelp(ClientInfo *p, ConfClient *pCC, char *Arg) {
+  struct COMMAND_TABLE *pTbl = commandtable;
 
-   if(CustomHelp != NULL) {
-      BufPrintf(p,"%s",CustomHelp);
-   }
-   else {
-      BufPrintf(p,"Commands:\r");
+  if (CustomHelp != NULL) {
+    BufPrintf(p, "%s", CustomHelp);
+  } else {
+    BufPrintf(p, "Commands:\r");
 
-      pTbl = commandtable;
-      while(pTbl->CmdString != NULL) {
-         if(!(pTbl->Flags & CMD_FLAG_NOLIST) &&
-            (!(pTbl->Flags & CMD_FLAG_ADMIN) || pCC->bAdmin) &&
-            (!(pTbl->Flags & CMD_FLAG_SYSOP) || pCC->bSysop) &&
-            (!(pTbl->Flags & CMD_FLAG_SCRIPT) || pCC->bCmdLine) &&
-            (!(pTbl->Flags & CMD_FLAG_NOSCRIPT) || !pCC->bCmdLine) &&
-            (!(pTbl->Flags & CMD_FLAG_NEED_DISK) || EnableDiskCommands) &&
-            (!(pTbl->Flags & CMD_FLAG_LURK) || !bLurkDisabled))
-         {
-            BufPrintf(p,".%s:\r   %s\r",pTbl->CmdString,pTbl->HelpString);
-         }
-         pTbl++;
+    pTbl = commandtable;
+    while (pTbl->CmdString != NULL) {
+      if (!(pTbl->Flags & CMD_FLAG_NOLIST) &&
+          (!(pTbl->Flags & CMD_FLAG_ADMIN) || pCC->bAdmin) &&
+          (!(pTbl->Flags & CMD_FLAG_SYSOP) || pCC->bSysop) &&
+          (!(pTbl->Flags & CMD_FLAG_SCRIPT) || pCC->bCmdLine) &&
+          (!(pTbl->Flags & CMD_FLAG_NOSCRIPT) || !pCC->bCmdLine) &&
+          (!(pTbl->Flags & CMD_FLAG_NEED_DISK) || EnableDiskCommands) &&
+          (!(pTbl->Flags & CMD_FLAG_LURK) || !bLurkDisabled)) {
+        BufPrintf(p, ".%s:\r   %s\r", pTbl->CmdString, pTbl->HelpString);
       }
-   }
+      pTbl++;
+    }
+  }
 }
 
 // Process conference command
-void ConferenceCmd(ClientInfo *p,ConfClient *pCC,char *Cmd)
-{
-   int i = -1 ;
-   int Result = -1;
-   int InitialCount = -1;
-   int CurrentCmd = -1;
-   int CmdsMatched = -1;
-   int bFirstLoop = TRUE;
-   char *cp = NULL;
-   char *Arg = NULL;
-   struct COMMAND_TABLE *pTbl = commandtable;
-   char *CmdLine = strdup(Cmd);
-   char *NextCommand = CmdLine;
-   char *Command = NULL;
-   int QuoteCount = 0;
-   ClientInfo DummyClient;
+void ConferenceCmd(ClientInfo *p, ConfClient *pCC, char *Cmd) {
+  int i = -1;
+  int Result = -1;
+  int InitialCount = -1;
+  int CurrentCmd = -1;
+  int CmdsMatched = -1;
+  int bFirstLoop = TRUE;
+  char *cp = NULL;
+  char *Arg = NULL;
+  struct COMMAND_TABLE *pTbl = commandtable;
+  char *CmdLine = strdup(Cmd);
+  char *NextCommand = CmdLine;
+  char *Command = NULL;
+  int QuoteCount = 0;
+  ClientInfo DummyClient;
 
-   DummyClient.Buf = NULL;
-   Rcode = TBD_OK;
+  DummyClient.Buf = NULL;
+  Rcode = TBD_OK;
 
-   for( ; ; ) {
-      bLogCmd = TRUE;   // assume we'll log this command
-      if(bFirstLoop) {
-         bFirstLoop = FALSE;
-         if(p == NULL) {
-         // no ClientInfo, use a the dummy
-            DummyClient.BufSize = CONF_BUF_SIZE;
-            if((DummyClient.Buf = malloc(DummyClient.BufSize)) == NULL) {
-               LOG_ERROR(("ConferenceCmd: Error: malloc failed\n"));
-               break;
-            }
-            DummyClient.p = piLinkConf;
-            p = &DummyClient;
-         }
-
-         if(CmdLine == NULL) {
-            LOG_ERROR(("ConferenceCmd: Error: malloc failed\n"));
-            break;
-         }
-         p->Count = 0;  // init for BufPrintf
-         BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-         InitialCount = p->Count;
+  for (;;) {
+    bLogCmd = TRUE; // assume we'll log this command
+    if (bFirstLoop) {
+      bFirstLoop = FALSE;
+      if (p == NULL) {
+        // no ClientInfo, use a the dummy
+        DummyClient.BufSize = CONF_BUF_SIZE;
+        if ((DummyClient.Buf = malloc(DummyClient.BufSize)) == NULL) {
+          LOG_ERROR(("ConferenceCmd: Error: malloc failed\n"));
+          break;
+        }
+        DummyClient.p = piLinkConf;
+        p = &DummyClient;
       }
 
-      CmdsMatched = 0;
-      if((cp = NextCommand) == NULL) {
-         break;
+      if (CmdLine == NULL) {
+        LOG_ERROR(("ConferenceCmd: Error: malloc failed\n"));
+        break;
       }
-      NextCommand = NULL;
+      p->Count = 0; // init for BufPrintf
+      BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+      InitialCount = p->Count;
+    }
 
-      while(*cp == ' ') {
-         cp++;
+    CmdsMatched = 0;
+    if ((cp = NextCommand) == NULL) {
+      break;
+    }
+    NextCommand = NULL;
+
+    while (*cp == ' ') {
+      cp++;
+    }
+
+    if (*cp == '.') {
+      cp++;
+    }
+
+    if (*cp == 0) {
+      break;
+    }
+
+    // Find next command
+
+    Command = cp;
+    while (*cp) {
+      if (*cp == ';') {
+        if ((QuoteCount & 1) == 0) {
+          *cp++ = 0;
+          NextCommand = cp;
+          break;
+        }
+      } else if (*cp == '"') {
+        QuoteCount++;
       }
+      cp++;
+    }
 
-      if(*cp == '.') {
-         cp++;
+    pTbl = commandtable;
+    for (i = 0; pTbl->CmdString != NULL; i++) {
+      if ((Result = MatchCmd(Command, pTbl->CmdString))) {
+        CmdsMatched++;
+        CurrentCmd = i;
+        if (Result == 2) {
+          // Exact match found
+          CmdsMatched = 1;
+          break;
+        }
       }
+      pTbl++;
+    }
 
-      if(*cp == 0) {
-         break;
-      }
-
-   // Find next command
-
-      Command = cp;
-      while(*cp) {
-         if(*cp == ';') {
-            if((QuoteCount & 1) == 0) {
-               *cp++ = 0;
-               NextCommand = cp;
-               break;
-            }
-         }
-         else if(*cp == '"') {
-            QuoteCount++;
-         }
-         cp++;
-      }
-
-      pTbl = commandtable;
-      for(i = 0; pTbl->CmdString != NULL; i++) {
-         if((Result = MatchCmd(Command,pTbl->CmdString))) {
-            CmdsMatched++;
-            CurrentCmd = i;
-            if(Result == 2) {
-            // Exact match found
-               CmdsMatched = 1;
-               break;
-            }
-         }
-         pTbl++;
-      }
-
-      if(CmdsMatched > 1) {
+    if (CmdsMatched > 1) {
       // Ambiguous
-         BufPrintf(p,"Error: Command is ambiguous.\r");
-         Rcode = TBD_ERR_INVALID_CMD;
-         break;
-      }
-      
-      if(CmdsMatched == 0) {
+      BufPrintf(p, "Error: Command is ambiguous.\r");
+      Rcode = TBD_ERR_INVALID_CMD;
+      break;
+    }
+
+    if (CmdsMatched == 0) {
       // not found
-         EventHook("command %s %s",pCC->Callsign,CmdLine);
-         Rcode = TBD_ERR_INVALID_CMD;
-         break;
-      }
+      EventHook("command %s %s", pCC->Callsign, CmdLine);
+      Rcode = TBD_ERR_INVALID_CMD;
+      break;
+    }
 
-      cp = Command;
-      while(*cp && *cp != ' ') {
-         cp++;
-      }
-      while(*cp && *cp == ' ') {
-         cp++;
-      }
+    cp = Command;
+    while (*cp && *cp != ' ') {
+      cp++;
+    }
+    while (*cp && *cp == ' ') {
+      cp++;
+    }
 
-      pTbl = &commandtable[CurrentCmd];
-      if(pTbl->Flags & CMD_FLAG_NEED_DISK && !EnableDiskCommands) {
+    pTbl = &commandtable[CurrentCmd];
+    if (pTbl->Flags & CMD_FLAG_NEED_DISK && !EnableDiskCommands) {
       // Command needs disk access and disk is disabled
-         Rcode = TBD_ERR_NO_DISK;
-         break;
-      }
+      Rcode = TBD_ERR_NO_DISK;
+      break;
+    }
 
-      if(pTbl->Flags & CMD_FLAG_NOSCRIPT && pCC->bCmdLine) {
-         Rcode = TBD_ERR_INVALID_CMD;
-         break;
-      }
-      
-      if(pTbl->Flags & CMD_FLAG_SCRIPT && !pCC->bCmdLine) {
-         Rcode = TBD_ERR_INVALID_CMD;
-         break;
-      }
-      
-      if((!(pTbl->Flags & CMD_FLAG_ADMIN) || pCC->bAdmin) &&
-         (!(pTbl->Flags & CMD_FLAG_SYSOP) || pCC->bSysop))
-      {
-         Arg = strdup(cp);
-         pTbl->CmdHandler(p,pCC,Arg);
-         free(Arg);
-      }
-      if(bLogCmd) {
-         LOG_NORM(("%s: \"%s\" (%d).\n",pCC->Callsign,Command,Rcode));
-      }
-      if(Rcode != TBD_OK) {
-         break;
-      }
-   }
+    if (pTbl->Flags & CMD_FLAG_NOSCRIPT && pCC->bCmdLine) {
+      Rcode = TBD_ERR_INVALID_CMD;
+      break;
+    }
 
-   if(p->Count > InitialCount && !pCC->bCmdLine) {
-   // send response
-      p->Count++; // include terminating null
-      SendBuf2(p,pCC,FALSE);
-   }
+    if (pTbl->Flags & CMD_FLAG_SCRIPT && !pCC->bCmdLine) {
+      Rcode = TBD_ERR_INVALID_CMD;
+      break;
+    }
 
-// Save the result code and text for possible use by SayResult
-   if(LastCmdText != NULL) {
-      free(LastCmdText);
-      LastCmdText = NULL;
-   }
+    if ((!(pTbl->Flags & CMD_FLAG_ADMIN) || pCC->bAdmin) &&
+        (!(pTbl->Flags & CMD_FLAG_SYSOP) || pCC->bSysop)) {
+      Arg = strdup(cp);
+      pTbl->CmdHandler(p, pCC, Arg);
+      free(Arg);
+    }
+    if (bLogCmd) {
+      LOG_NORM(("%s: \"%s\" (%d).\n", pCC->Callsign, Command, Rcode));
+    }
+    if (Rcode != TBD_OK) {
+      break;
+    }
+  }
 
-   LastRcode = Rcode;
-   if(p->Count > InitialCount) {
-      LastCmdText = strdup(&p->Buf[strlen(NDATA)+1]);
-   }
-   LastCmd = pTbl->CmdString;
+  if (p->Count > InitialCount && !pCC->bCmdLine) {
+    // send response
+    p->Count++; // include terminating null
+    SendBuf2(p, pCC, FALSE);
+  }
 
-   if(CmdLine != NULL) {
-      free(CmdLine);
-   }
+  // Save the result code and text for possible use by SayResult
+  if (LastCmdText != NULL) {
+    free(LastCmdText);
+    LastCmdText = NULL;
+  }
 
-   if(DummyClient.Buf != NULL) {
-      free(DummyClient.Buf);
-   }
+  LastRcode = Rcode;
+  if (p->Count > InitialCount) {
+    LastCmdText = strdup(&p->Buf[strlen(NDATA) + 1]);
+  }
+  LastCmd = pTbl->CmdString;
+
+  if (CmdLine != NULL) {
+    free(CmdLine);
+  }
+
+  if (DummyClient.Buf != NULL) {
+    free(DummyClient.Buf);
+  }
 }
-
 
 // Return number of milliseconds of time since p
-int TimeLapse(struct timeval *p)
-{
-   int DeltaSeconds = TimeNow.tv_sec - p->tv_sec;
+int TimeLapse(struct timeval *p) {
+  int DeltaSeconds = TimeNow.tv_sec - p->tv_sec;
 
-   if(DeltaSeconds > (0x7fffffff / 1000)) {
-   // TimeLapse is too big to express in milliseconds, just return 
-   // the max we can.
-      return 0x7fffffff;
-   }
-   return (DeltaSeconds * 1000) + 
-          ((TimeNow.tv_usec - p->tv_usec) / 1000);
+  if (DeltaSeconds > (0x7fffffff / 1000)) {
+    // TimeLapse is too big to express in milliseconds, just return
+    // the max we can.
+    return 0x7fffffff;
+  }
+  return (DeltaSeconds * 1000) + ((TimeNow.tv_usec - p->tv_usec) / 1000);
 }
 
-void Send2(ConfClient *pCC,void *Data,int Count,int bControlPort)
-{
-   ConfServer *pCS = pCC->pCS;
-   int TxLen;
-   IPAdrUnion HisAdr;
-   int Socket;
+void Send2(ConfClient *pCC, void *Data, int Count, int bControlPort) {
+  ConfServer *pCS = pCC->pCS;
+  int TxLen;
+  IPAdrUnion HisAdr;
+  int Socket;
 
-   if(bEchoLinkEnabled || !pCS->biLinkConf) {
-      HisAdr.ADDR = pCC->HisAdr.ADDR;
-      HisAdr.i.sin_family = AF_INET;
-      if(bControlPort) {
+  if (bEchoLinkEnabled || !pCS->biLinkConf) {
+    HisAdr.ADDR = pCC->HisAdr.ADDR;
+    HisAdr.i.sin_family = AF_INET;
+    if (bControlPort) {
       // rtcp (control)
-         Socket = pCS->pControl->Socket;
-         HisAdr.PORT = htons((unsigned short) (pCS->AudioPort + 1));
-      }
-      else {
+      Socket = pCS->pControl->Socket;
+      HisAdr.PORT = htons((unsigned short)(pCS->AudioPort + 1));
+    } else {
       // Even = audio port
-         Socket = pCS->pAudio->Socket;
-         HisAdr.PORT = htons((unsigned short) pCS->AudioPort);
-      }
+      Socket = pCS->pAudio->Socket;
+      HisAdr.PORT = htons((unsigned short)pCS->AudioPort);
+    }
 
-      TxLen = sendto(Socket,Data,Count,0,&HisAdr.s,sizeof(HisAdr));
+    TxLen = sendto(Socket, Data, Count, 0, &HisAdr.s, sizeof(HisAdr));
 
-      if(Count != TxLen) {
-         pCS->TxErrs++;
-         LOG_ERROR(("Send2(): sendto() failed, %s",Err2String(ERROR_CODE)));
-      }
-      else {
-         pCS->TxCount++;
-         pCC->TxBytes += Count + HEADER_OVERHEAD;
-         pCS->TxBytes += Count + HEADER_OVERHEAD;
-         TxBytesAllConf += Count + HEADER_OVERHEAD;
-      }
-   }
+    if (Count != TxLen) {
+      pCS->TxErrs++;
+      LOG_ERROR(("Send2(): sendto() failed, %s", Err2String(ERROR_CODE)));
+    } else {
+      pCS->TxCount++;
+      pCC->TxBytes += Count + HEADER_OVERHEAD;
+      pCS->TxBytes += Count + HEADER_OVERHEAD;
+      TxBytesAllConf += Count + HEADER_OVERHEAD;
+    }
+  }
 }
 
-void SendBuf2(ClientInfo *p,ConfClient *pCC,int bControLPort)
-{
-   Send2(pCC,p->Buf,p->Count,bControLPort);
+void SendBuf2(ClientInfo *p, ConfClient *pCC, int bControLPort) {
+  Send2(pCC, p->Buf, p->Count, bControLPort);
 }
 
-void CalcBW(ConfServer *pCS,int bClear)
-{
-   int DeltaT = TimeLapse(&pCS->StartTime);
+void CalcBW(ConfServer *pCS, int bClear) {
+  int DeltaT = TimeLapse(&pCS->StartTime);
 
-   if(DeltaT > 5000) {
-   // only calculate bandwidth based on samples >= 5 seconds
-      if(pCS->StartTime.tv_sec != 0) {
-         pCS->TxBandWidth = (pCS->TxBytes - pCS->TxBytesStart) * 8 / DeltaT;
-         if(pCS->TxBandWidth > pCS->PeakTxBandWidth) {
-            pCS->PeakTxBandWidth = pCS->TxBandWidth;
-            pCS->PeakTxBandWidthTime = TimeNow.tv_sec;
-         }
-
-         pCS->RxBandWidth = (pCS->RxBytes - pCS->RxBytesStart) * 8 / DeltaT;
-         if(pCS->RxBandWidth > pCS->PeakRxBandWidth) {
-            pCS->PeakRxBandWidth = pCS->RxBandWidth;
-            pCS->PeakRxBandWidthTime = TimeNow.tv_sec;
-         }
-      }
-   }
-
-   if(bClear) {
-      if(pCS->TxBytes > 1000000) {
-         pCS->TxMBytes += pCS->TxBytes / 1000000;
-         pCS->TxBytes %= 1000000;
+  if (DeltaT > 5000) {
+    // only calculate bandwidth based on samples >= 5 seconds
+    if (pCS->StartTime.tv_sec != 0) {
+      pCS->TxBandWidth = (pCS->TxBytes - pCS->TxBytesStart) * 8 / DeltaT;
+      if (pCS->TxBandWidth > pCS->PeakTxBandWidth) {
+        pCS->PeakTxBandWidth = pCS->TxBandWidth;
+        pCS->PeakTxBandWidthTime = TimeNow.tv_sec;
       }
 
-      if(pCS->RxBytes > 1000000) {
-         pCS->RxMBytes += pCS->RxBytes / 1000000;
-         pCS->RxBytes %= 1000000;
+      pCS->RxBandWidth = (pCS->RxBytes - pCS->RxBytesStart) * 8 / DeltaT;
+      if (pCS->RxBandWidth > pCS->PeakRxBandWidth) {
+        pCS->PeakRxBandWidth = pCS->RxBandWidth;
+        pCS->PeakRxBandWidthTime = TimeNow.tv_sec;
       }
+    }
+  }
 
-      if(TxBytesAllConf > 1000000) {
-         TxMBytesAllConf += TxBytesAllConf / 1000000;
-         TxBytesAllConf %= 1000000;
-      }
+  if (bClear) {
+    if (pCS->TxBytes > 1000000) {
+      pCS->TxMBytes += pCS->TxBytes / 1000000;
+      pCS->TxBytes %= 1000000;
+    }
 
-      if(RxBytesAllConf > 1000000) {
-         RxMBytesAllConf += RxBytesAllConf / 1000000;
-         RxBytesAllConf %= 1000000;
-      }
+    if (pCS->RxBytes > 1000000) {
+      pCS->RxMBytes += pCS->RxBytes / 1000000;
+      pCS->RxBytes %= 1000000;
+    }
 
+    if (TxBytesAllConf > 1000000) {
+      TxMBytesAllConf += TxBytesAllConf / 1000000;
+      TxBytesAllConf %= 1000000;
+    }
 
-      pCS->StartTime = TimeNow;
-      pCS->TxBytesStart = pCS->TxBytes;
-      pCS->RxBytesStart = pCS->RxBytes; 
-   }
+    if (RxBytesAllConf > 1000000) {
+      RxMBytesAllConf += RxBytesAllConf / 1000000;
+      RxBytesAllConf %= 1000000;
+    }
+
+    pCS->StartTime = TimeNow;
+    pCS->TxBytesStart = pCS->TxBytes;
+    pCS->RxBytesStart = pCS->RxBytes;
+  }
 }
 
-void SendToAllSysops(ClientInfo *p,ConfServer *pCS)
-{
-   struct avl_traverser avl_trans;
-   ConfClient *pCC = avl_t_first(&avl_trans,pCS->ConfTree);
+void SendToAllSysops(ClientInfo *p, ConfServer *pCS) {
+  struct avl_traverser avl_trans;
+  ConfClient *pCC = avl_t_first(&avl_trans, pCS->ConfTree);
 
-   while(pCC != NULL) {
-      if(pCC->bSysop) {
-         SendBuf2(p,pCC,FALSE);
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+  while (pCC != NULL) {
+    if (pCC->bSysop) {
+      SendBuf2(p, pCC, FALSE);
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 }
 
-void SendSDES(ConfServer *pCS,ConfClient *pCC)
-{
-   int i = pCC->Proto;
-   if(gProtoData[i].SDESLen == 0 || 
-      pCC->bTxtExtension != gProtoData[i].bTxtExtension) 
-   {
-      GenSDES(i+1,pCC->bTxtExtension);
-   }
+void SendSDES(ConfServer *pCS, ConfClient *pCC) {
+  int i = pCC->Proto;
+  if (gProtoData[i].SDESLen == 0 ||
+      pCC->bTxtExtension != gProtoData[i].bTxtExtension) {
+    GenSDES(i + 1, pCC->bTxtExtension);
+  }
 
-   if(gProtoData[i].SDESLen > 0) {
-      Send2(pCC,gProtoData[i].OurSDES,gProtoData[i].SDESLen,TRUE);
-   }
+  if (gProtoData[i].SDESLen > 0) {
+    Send2(pCC, gProtoData[i].OurSDES, gProtoData[i].SDESLen, TRUE);
+  }
 }
 
-/* 
+/*
    For now we assume that RTP clients are running GSM so all we need to
    do is fudge the version numbers
 */
-void ConvertRTP2iLink(ProtoData *pPDat, char *inBuf,int inLen,int bNewStream)
-{
-   ProtoData *pPD = &pPDat[ILINK_RTP_VERSION - 1];
-   rtp_hdr_t *pRTP = (rtp_hdr_t *) (pPD->Temp);
+void ConvertRTP2iLink(ProtoData *pPDat, char *inBuf, int inLen,
+                      int bNewStream) {
+  ProtoData *pPD = &pPDat[ILINK_RTP_VERSION - 1];
+  rtp_hdr_t *pRTP = (rtp_hdr_t *)(pPD->Temp);
 
-   pPD->Data[0]= pPD->Temp;
-   memcpy(pPD->Data[0],inBuf,inLen);
-   pPD->DataLen[0] = inLen;
-   
-   pRTP->ssrc = 0;
-   pRTP->version = ILINK_RTP_VERSION;
+  pPD->Data[0] = pPD->Temp;
+  memcpy(pPD->Data[0], inBuf, inLen);
+  pPD->DataLen[0] = inLen;
+
+  pRTP->ssrc = 0;
+  pRTP->version = ILINK_RTP_VERSION;
 }
 
-void ConvertiLink2RTP(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream)
-{
-   ProtoData *pPD = &pPDat[RTP_VERSION -1];
-   rtp_hdr_t *pRTP = (rtp_hdr_t *) (pPD->Temp);
+void ConvertiLink2RTP(ProtoData *pPDat, char *inBuf, int inLen,
+                      int bNewStream) {
+  ProtoData *pPD = &pPDat[RTP_VERSION - 1];
+  rtp_hdr_t *pRTP = (rtp_hdr_t *)(pPD->Temp);
 
-   if(pPDat[PROTO_ILINK].Type == PKT_TYPE_AUDIO) {
-      pPD->Data[0]= pPD->Temp;
-      memcpy(pPD->Data[0],inBuf,inLen);
-      pPD->DataLen[0] = inLen;
+  if (pPDat[PROTO_ILINK].Type == PKT_TYPE_AUDIO) {
+    pPD->Data[0] = pPD->Temp;
+    memcpy(pPD->Data[0], inBuf, inLen);
+    pPD->DataLen[0] = inLen;
 
-      pRTP->ssrc = OurNodeID;
-      pRTP->version = RTP_VERSION;
-   }
+    pRTP->ssrc = OurNodeID;
+    pRTP->version = RTP_VERSION;
+  }
 }
 
 // Speak Freely sends 10 GSM frames per UDP packet,  EchoLink
-// can't deal with that so we break the first Speak Freely packet into 
-// 2 UDP packets of 4 GSM frames plus 2 left over.  
+// can't deal with that so we break the first Speak Freely packet into
+// 2 UDP packets of 4 GSM frames plus 2 left over.
 // The next time we'll use the 2 left over plus the 10 new frames to
 // create 3 EchoLink UDP packets.
 //
@@ -7198,1048 +6847,979 @@ void ConvertiLink2RTP(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream)
 // ProtoData.Temp after old Speak Freely Packet:
 // <iLink Frame n+3> <iLink Frame n+4> <iLink Frame n+2>
 //
-void ConvertSF2iLink(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream)
-{
-   static u_int16 Sequence = 1;
-   ProtoData *pPD = &pPDat[ILINK_RTP_VERSION-1];
-   static int bEvenPacket = TRUE;
-   soundbuf *pSFHdr = (soundbuf *) inBuf;
-   int DataLen = ntohl(pSFHdr->buffer.buffer_len) - sizeof(u_int16);
-   char *pGSM_In = pSFHdr->buffer.buffer_val + sizeof(u_int16);
-   int Count = 0;
-   union {
-      char *cp;
-      rtp_hdr_t *pRTP;
-   } u;
-    
-   u.cp = pPD->Temp;
+void ConvertSF2iLink(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream) {
+  static u_int16 Sequence = 1;
+  ProtoData *pPD = &pPDat[ILINK_RTP_VERSION - 1];
+  static int bEvenPacket = TRUE;
+  soundbuf *pSFHdr = (soundbuf *)inBuf;
+  int DataLen = ntohl(pSFHdr->buffer.buffer_len) - sizeof(u_int16);
+  char *pGSM_In = pSFHdr->buffer.buffer_val + sizeof(u_int16);
+  int Count = 0;
+  union {
+    char *cp;
+    rtp_hdr_t *pRTP;
+  } u;
 
+  u.cp = pPD->Temp;
 
-   if(bNewStream) {
-   // Toss any left over data, this is a new talker
-      bEvenPacket = TRUE;
-   }
+  if (bNewStream) {
+    // Toss any left over data, this is a new talker
+    bEvenPacket = TRUE;
+  }
 
-   if(bEvenPacket) {
-      bEvenPacket = FALSE;
-      pPD->Data[0] = pPD->Temp;
-      pPD->DataLen[0] = ILINK_RTP_FRAME_LEN;
-      
-      pPD->Data[1] = &pPD->Temp[ILINK_RTP_FRAME_LEN];
-      pPD->DataLen[1] = ILINK_RTP_FRAME_LEN;
-      
-      pPD->DataLen[2] = 0;
+  if (bEvenPacket) {
+    bEvenPacket = FALSE;
+    pPD->Data[0] = pPD->Temp;
+    pPD->DataLen[0] = ILINK_RTP_FRAME_LEN;
 
-   }
-   else {
-   // Odd packet, complete last partial packet
-      bEvenPacket = TRUE;
-      Count = 2 * GSM_FRAME_LEN;
-      pPD->Data[0] = &pPD->Temp[ILINK_RTP_FRAME_LEN*2];
-      pPD->DataLen[0] = ILINK_RTP_FRAME_LEN;
-      memcpy(&pPD->Data[0][RTP_HDR_SIZE+Count],pGSM_In,Count);
-      pGSM_In += Count;
-      DataLen -= Count;
-      
-      pPD->Data[1] = pPD->Temp;
-      pPD->DataLen[1] = ILINK_RTP_FRAME_LEN;
-      
-      pPD->Data[2] = &pPD->Temp[ILINK_RTP_FRAME_LEN];
-      pPD->DataLen[2] = ILINK_RTP_FRAME_LEN;
-   }
+    pPD->Data[1] = &pPD->Temp[ILINK_RTP_FRAME_LEN];
+    pPD->DataLen[1] = ILINK_RTP_FRAME_LEN;
 
-   while(DataLen > 0) {
-      u.pRTP->version = ILINK_RTP_VERSION;
-      u.pRTP->p = 0;
-      u.pRTP->x = 0;
-      u.pRTP->cc = 0;
-      u.pRTP->m = 0;
-      u.pRTP->pt = RTP_PT_GSM;
-      u.pRTP->seq = htons(Sequence++);
-      u.pRTP->ts = 0;
-      u.pRTP->ssrc = 0;
-      
-      Count = DataLen;
-      if(Count >= GSM_FRAME_LEN * 4) {
-         Count = GSM_FRAME_LEN * 4;
-      }
-      memcpy(&u.pRTP->csrc,pGSM_In,Count);
-      
-      pGSM_In += Count;
-      DataLen -= Count;
-      u.cp = u.cp + ILINK_RTP_FRAME_LEN;
-   }
+    pPD->DataLen[2] = 0;
+
+  } else {
+    // Odd packet, complete last partial packet
+    bEvenPacket = TRUE;
+    Count = 2 * GSM_FRAME_LEN;
+    pPD->Data[0] = &pPD->Temp[ILINK_RTP_FRAME_LEN * 2];
+    pPD->DataLen[0] = ILINK_RTP_FRAME_LEN;
+    memcpy(&pPD->Data[0][RTP_HDR_SIZE + Count], pGSM_In, Count);
+    pGSM_In += Count;
+    DataLen -= Count;
+
+    pPD->Data[1] = pPD->Temp;
+    pPD->DataLen[1] = ILINK_RTP_FRAME_LEN;
+
+    pPD->Data[2] = &pPD->Temp[ILINK_RTP_FRAME_LEN];
+    pPD->DataLen[2] = ILINK_RTP_FRAME_LEN;
+  }
+
+  while (DataLen > 0) {
+    u.pRTP->version = ILINK_RTP_VERSION;
+    u.pRTP->p = 0;
+    u.pRTP->x = 0;
+    u.pRTP->cc = 0;
+    u.pRTP->m = 0;
+    u.pRTP->pt = RTP_PT_GSM;
+    u.pRTP->seq = htons(Sequence++);
+    u.pRTP->ts = 0;
+    u.pRTP->ssrc = 0;
+
+    Count = DataLen;
+    if (Count >= GSM_FRAME_LEN * 4) {
+      Count = GSM_FRAME_LEN * 4;
+    }
+    memcpy(&u.pRTP->csrc, pGSM_In, Count);
+
+    pGSM_In += Count;
+    DataLen -= Count;
+    u.cp = u.cp + ILINK_RTP_FRAME_LEN;
+  }
 }
 
 // Echolink sends 4 GSM frames per UDP packet, Speak Freely sends 10.
-// We repack the EchoLink frame so they contain the same number of GSM 
+// We repack the EchoLink frame so they contain the same number of GSM
 // frames as sent by a Speak Freely client.
 //
 // iLinkCount =-1: Initialize header
 // iLinkCount = 0: copy first 4 GSM frames in to buffer, return DataLen = 0
 // iLinkCount = 1: copy next 4 GSM frames in to buffer, return DataLen = 0
-// iLinkCount = 2: copy last 4 GSM frames in to buffer, return 
+// iLinkCount = 2: copy last 4 GSM frames in to buffer, return
 //                 DataLen = size of Speak Freely packet with 10 GSM frames
-// iLinkCount = 3: copy 2 left over GSM frames to beginning of buffer, 
+// iLinkCount = 3: copy 2 left over GSM frames to beginning of buffer,
 //                 copy 4 new GSM frames into buffer, return DataLen = 0
-// iLinkCount = 4: copy last 4 GSM frames into buffer, clear iLinkCount, return 
+// iLinkCount = 4: copy last 4 GSM frames into buffer, clear iLinkCount, return
 //                 DataLen = size of Speak Freely packet with 10 GSM frames
 //
-void ConvertiLink2SF(ProtoData *pPDat,char *inBuf,int inLen,int bNewStream)
-{
-   int HdrSize = sizeof(rtp_hdr_t) - sizeof(u_int32);
-   int DataLen = inLen - HdrSize;
-   ProtoData *pPD = &pPDat[PROTO_SF];
-   soundbuf *pSFHdr = (soundbuf *) pPD->Temp;
-   char *pGSM_data = pSFHdr->buffer.buffer_val + sizeof(u_int16);
-   u_int16 *pOrigDataLen = (u_int16 *) pSFHdr->buffer.buffer_val;
+void ConvertiLink2SF(ProtoData *pPDat, char *inBuf, int inLen, int bNewStream) {
+  int HdrSize = sizeof(rtp_hdr_t) - sizeof(u_int32);
+  int DataLen = inLen - HdrSize;
+  ProtoData *pPD = &pPDat[PROTO_SF];
+  soundbuf *pSFHdr = (soundbuf *)pPD->Temp;
+  char *pGSM_data = pSFHdr->buffer.buffer_val + sizeof(u_int16);
+  u_int16 *pOrigDataLen = (u_int16 *)pSFHdr->buffer.buffer_val;
 
-   if(pPDat[PROTO_ILINK].Type == PKT_TYPE_AUDIO) {
-      if(bNewStream) {
+  if (pPDat[PROTO_ILINK].Type == PKT_TYPE_AUDIO) {
+    if (bNewStream) {
       // Toss any left over data, this is a new talker
-         pPDat->iLinkCount = 0;
+      pPDat->iLinkCount = 0;
+    }
+
+    switch (pPDat->iLinkCount++) {
+    case 0:
+      // Initialize Speak Freely Header
+      pSFHdr->compression = htonl(fCompGSM | fProtocol);
+      pSFHdr->buffer.buffer_len = htonl(GSM_FRAME_LEN * 10 + sizeof(u_int16));
+      *pOrigDataLen = htons(SF_AUDIO_SAMPLES_PER_PACKET);
+      memset(pSFHdr->sendinghost, 0, sizeof(pSFHdr->sendinghost));
+      if (pPDat == gProtoData) {
+        strncpy(pSFHdr->sendinghost, ClientTalking->Callsign,
+                sizeof(pSFHdr->sendinghost));
+      } else {
+        strncpy(pSFHdr->sendinghost, pPDat->Callsign,
+                sizeof(pSFHdr->sendinghost));
       }
+      break;
 
-      switch(pPDat->iLinkCount++) {
-         case 0:
-         // Initialize Speak Freely Header
-            pSFHdr->compression = htonl(fCompGSM | fProtocol);
-            pSFHdr->buffer.buffer_len = htonl(GSM_FRAME_LEN*10+sizeof(u_int16));
-            *pOrigDataLen = htons(SF_AUDIO_SAMPLES_PER_PACKET);
-            memset(pSFHdr->sendinghost,0,sizeof(pSFHdr->sendinghost));
-            if(pPDat == gProtoData) {
-               strncpy(pSFHdr->sendinghost,ClientTalking->Callsign,
-                       sizeof(pSFHdr->sendinghost));
-            }
-            else {
-               strncpy(pSFHdr->sendinghost,pPDat->Callsign,
-                       sizeof(pSFHdr->sendinghost));
-            }
-            break;
+    case 1:
+      pGSM_data += (4 * GSM_FRAME_LEN);
+      break;
 
-         case 1:
-            pGSM_data += (4 * GSM_FRAME_LEN);
-            break;
+    case 2:
+      pGSM_data += (8 * GSM_FRAME_LEN);
+      pPD->Data[0] = pPD->Temp;
+      pPD->DataLen[0] = SF_GSM_FRAME_LEN;
+      break;
 
-         case 2:
-            pGSM_data += (8 * GSM_FRAME_LEN);
-            pPD->Data[0] = pPD->Temp;
-            pPD->DataLen[0] = SF_GSM_FRAME_LEN;
-            break;
+    case 3:
+      // Move the 2 extra GSM frames down to the head of the buffer
+      memcpy(pGSM_data, pGSM_data + (10 * GSM_FRAME_LEN), GSM_FRAME_LEN * 2);
+      pGSM_data += (2 * GSM_FRAME_LEN);
+      break;
 
-         case 3:
-         // Move the 2 extra GSM frames down to the head of the buffer
-            memcpy(pGSM_data,pGSM_data + (10 * GSM_FRAME_LEN),GSM_FRAME_LEN*2);
-            pGSM_data += (2 * GSM_FRAME_LEN);
-            break;
-
-         case 4:
-            pGSM_data += (6 * GSM_FRAME_LEN);
-            pPDat->iLinkCount = 0;
-            pPD->Data[0] = pPD->Temp;
-            pPD->DataLen[0] = SF_GSM_FRAME_LEN;
-            break;
-      }
-      memcpy(pGSM_data,&inBuf[HdrSize],DataLen);
-   }
+    case 4:
+      pGSM_data += (6 * GSM_FRAME_LEN);
+      pPDat->iLinkCount = 0;
+      pPD->Data[0] = pPD->Temp;
+      pPD->DataLen[0] = SF_GSM_FRAME_LEN;
+      break;
+    }
+    memcpy(pGSM_data, &inBuf[HdrSize], DataLen);
+  }
 }
 
-
-// The iLink protocol is used as a common basis, i.e. either the InputProto 
+// The iLink protocol is used as a common basis, i.e. either the InputProto
 // or OutputProto must be PROTO_ILINK.
-void ConvertProtocol(
-   ProtoData *pProtoDat,
-   Protocol InputProto,
-   Protocol OutputProto,
-   int bNewStream)
-{
-   char *Buf;
-   int Len;
-   int i;
+void ConvertProtocol(ProtoData *pProtoDat, Protocol InputProto,
+                     Protocol OutputProto, int bNewStream) {
+  char *Buf;
+  int Len;
+  int i;
 
-   if(ProtoConvert[InputProto][OutputProto] != NULL) {
-      for(i = 0; i < MAX_CONV_PACKETS; i++) {
-         if((Len = pProtoDat[InputProto].DataLen[i]) > 0) {
-            Buf = pProtoDat[InputProto].Data[i];
-            if(i == 0 && bNewStream) {
-               ProtoConvert[InputProto][OutputProto](pProtoDat,Buf,Len,TRUE);
-            }
-            else {
-               ProtoConvert[InputProto][OutputProto](pProtoDat,Buf,Len,FALSE);
-            }
-         }
+  if (ProtoConvert[InputProto][OutputProto] != NULL) {
+    for (i = 0; i < MAX_CONV_PACKETS; i++) {
+      if ((Len = pProtoDat[InputProto].DataLen[i]) > 0) {
+        Buf = pProtoDat[InputProto].Data[i];
+        if (i == 0 && bNewStream) {
+          ProtoConvert[InputProto][OutputProto](pProtoDat, Buf, Len, TRUE);
+        } else {
+          ProtoConvert[InputProto][OutputProto](pProtoDat, Buf, Len, FALSE);
+        }
       }
-   }
-   pProtoDat[OutputProto].bDataValid = TRUE;
+    }
+  }
+  pProtoDat[OutputProto].bDataValid = TRUE;
 }
 
-int OurUser(ConfServer *pCS,char *Callsign)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   int Ret = FALSE;
+int OurUser(ConfServer *pCS, char *Callsign) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  int Ret = FALSE;
 
-   pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-   while(pCC != NULL) {
-      if(strcmp(pCC->Callsign,Callsign) == 0) {
+  pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+  while (pCC != NULL) {
+    if (strcmp(pCC->Callsign, Callsign) == 0) {
       // Yup he's one of ours
-         Ret = TRUE;
-         break;
-      }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
-
-   return Ret;
-}
-
-void ForwardCommandResponse(ClientInfo *p,ConfClient *pCC1)
-{
-   ConfClient *pCC;
-   struct avl_traverser avl_trans;
-   ConfServer *pCS = pCC1->pCS;
-   char *cp = strdup(&p->Buf[sizeof(NDATA)]);
-
-   if(cp != NULL) {
-      p->Count = 0;  // init for BufPrintf
-      BufPrintf(p,"%c" NDATA "%s>%s",ILINK_DATA_PACKET,pCC1->Callsign,cp);
-      free(cp);
-
-   // Forward all (remote) command responses to the command line client
-   // if he's in chat mode since he didn't need to use the .quote command
-   // to issue a command
-
-      if(bCmdLineChatMode) {
-         FwdTextCmdLine(p,p->Buf,&CmdLineCC);
-      }
-
-      if(ChatPort != 0) {
-         FwdTextCmdLine(p,p->Buf,&ChatCC);
-      }
-
-      pCC = &CmdLineCC;
-      while(pCC != NULL) {
-         if(pCC->bSentQuotedCmd) {
-            if(pCC == &CmdLineCC) {
-               if(!bCmdLineChatMode) {
-                  FwdTextCmdLine(p,p->Buf,&CmdLineCC);
-               }
-            }
-            else if(TimeLapse(&pCC->FirstAudioIn) > 30000) {
-            // Stop forwarding possible responses after 30 seconds
-               pCC->bSentQuotedCmd = FALSE;
-            }
-            else {
-               Send2(pCC,p->Buf,p->Count,FALSE);
-               break;
-            }
-         }
-
-         if(pCC == &CmdLineCC) {
-            pCC = (ConfClient *) avl_t_first(&avl_trans,pCS->ConfTree);
-         }
-         else {
-            pCC = (ConfClient *) avl_t_next(&avl_trans);
-         }
-      }
-   }
-}
-
-int DuplicateTextMsg(ClientInfo *p,ConfClient *pCC)
-{
-   int i;
-   int j;
-   unsigned short crc = 0;
-   int Ret = FALSE;
-   time_t Oldest = (time_t) -1;
-   int OldestEntry = 0;
-   DupTrackingEntry *pDup;
-   char *DupMessage;
-   char *cp;
-   ConfServer *pCS = pCC->pCS;
-   int TextLen = strlen(p->Buf);
-
-// Calculate a CRC of the text message
-// NB: exclude any SSRC appended to the message, there's a bug
-// in some versions of EchoLink that caused the SSRC to be corrupted
-// when text messages are forwarded.
-
-   for(i = 0; i < TextLen; i++) {
-      crc ^= p->Buf[i] << 8;
-      for(j = 0; j < 8; j++) {
-         if(crc & 0x8000) {
-            crc = crc << 1 ^ 0x1021;
-         }
-         else {
-            crc <<= 1;
-         }
-      }
-   }
-
-   pDup = DupTracking;
-   for(i = 0; i < MAX_DUP_TRACKING; i++) {
-      if(Oldest == (time_t) -1 || pDup->TimeStamp < Oldest) {
-         Oldest = pDup->TimeStamp;
-         OldestEntry = i;
-      }
-
-      if((TimeNow.tv_sec - pDup->TimeStamp) <= DUP_TRACKING_TIMEOUT &&
-         crc == pDup->crc)
-      {  // Duplicate!
-         pDup->TimeStamp = TimeNow.tv_sec;
-         if(!pDup->bLogged) {
-            pDup->bLogged = TRUE;
-            DupMessage = &p->Buf[sizeof(NDATA)];
-            if((cp = strchr(DupMessage,'\r')) != NULL) {
-            // remove CR
-               *cp = 0;
-            }
-            LOG_WARN(("Dup from %s, %s dropped (0x%x):\n",pDup->FirstFrom,
-                      pCC->Callsign,pDup->crc));
-            LOG_WARN(("%s\n",DupMessage));
-
-            p->Count = 0;  // init for BufPrintf
-            BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-            BufPrintf(p,"%s>Dup from %s, %s dropped.\r",ConferenceCall,
-                      pDup->FirstFrom,pCC->Callsign);
-            SendToAllSysops(p,pCS);
-         }
-         Ret = TRUE;
-         pCC->DupsReceived++;
-         pCS->DupsReceived++;
-         if(MaxDups != 0 && pCC->DupsReceived > MaxDups) {
-            pCS->DupDisconnects++;
-            LOG_ERROR(("Disconnecting %s too many dups.\n",pCC->Callsign));
-            DisconnectCC(p,pCC,"Loop disconnect!");
-
-         // We clobbered the buffer, reinitialize it for our response
-            p->Count = 0;  // init for BufPrintf
-            BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-            BufPrintf(p,"%s disconnected, too many dups.\r",pCC->Callsign);
-            pCS->bSendStationList = TRUE;
-            SendToAllSysops(p,pCS);
-         }
-         break;
-      }
-      pDup++;
-   }
-
-   if(!Ret) {
-   // Add new text message to the cache
-      pDup = &DupTracking[OldestEntry];
-      if(pDup->TimeStamp != 0 && 
-         (TimeNow.tv_sec - pDup->TimeStamp) <= DUP_TRACKING_TIMEOUT) 
-      {
-      // Play it safe and assume this is a duplicate
-         Ret = TRUE;
-         LOG_WARN(("DupTracking cache full!\n"));
-         LOG_WARN(("Oldest: %d\n",OldestEntry));
-         for(i = 0; i < MAX_DUP_TRACKING; i++) {
-            LOG_WARN(("%d: TimeStamp: %d, From:%s, CRC: %d\n",i,
-                      DupTracking[i].TimeStamp,DupTracking[i].FirstFrom,
-                      DupTracking[i].crc));
-         }
-      }
-      pDup->crc = crc;
-      pDup->TimeStamp = TimeNow.tv_sec;
-      pDup->bLogged = FALSE;
-      strncpy(pDup->FirstFrom,pCC->Callsign,MAX_CALL_LEN);
-   }
-
-   return Ret;
-}
-
-PacketType GetPacketType(ClientInfo *p,ConfClient *pCC)
-{
-   char *cp;
-   char *cp1;
-   int Len;
-   soundbuf *pSFHdr = (soundbuf *) p->Buf;
-   rtp_hdr_t *pRTP = (rtp_hdr_t *) p->Buf;
-   ConfServer *pCS = pCC->pCS;
-   PacketType Ret = PKT_TYPE_UNKNOWN;
-   FILE *fp;
-   int CallLen;
-   int Compression;
-
-   switch(pCC->Proto) {
-      case PROTO_SF:
-      // Speak Freely sends text via the RTCP port, so if it's on the RTP
-      // port it must be audio
-         Compression = (int) ntohl(pSFHdr->compression);
-         if(Compression == (fCompGSM | fProtocol)) {
-            pCC->CompressionType = RTP_PT_GSM;
-            Ret = PKT_TYPE_AUDIO;
-         }
-         else if(Compression == (fCompADPCM | fProtocol)) {
-            pCC->CompressionType = RTP_PT_DVI4_8K;
-            Ret = PKT_TYPE_AUDIO;
-         }
-         else if(Compression == fProtocol) {
-         // No compression (uLaw)
-            pCC->CompressionType = RTP_PT_PCMU;
-            Ret = PKT_TYPE_AUDIO;
-         }
-         else {
-            Ret = PKT_TYPE_IGNORE;
-            DLOG(DLOG_CODEC_TYPE,
-                 ("Ignoring SF CompressionType 0x%x from %s.\n",
-                  ntohl(pSFHdr->compression),CallLog(pCC)));
-         }
-         break;
-   
-      case PROTO_RTP:
-      // RTP doesn't send text so it must be audio
-         pCC->bSendSSRC = TRUE;  // always send ssrc for RTP
-         pCC->CompressionType = pRTP->pt;
-         switch(pRTP->pt) {
-            case RTP_PT_GSM:
-            case RTP_PT_DVI4_8K: // aka adpcm
-            case RTP_PT_PCMU:
-            case RTP_PT_G726:
-               Ret = PKT_TYPE_AUDIO;
-               break;
-            
-            default:
-               Ret = PKT_TYPE_IGNORE;
-               DLOG(DLOG_CODEC_TYPE,
-                    ("Ignoring RTP packet type 0x%x from %s.\n",pRTP->pt,
-                     CallLog(pCC)));
-               break;
-         }
-         break;
-   
-      case PROTO_ILINK:
-         switch(p->Buf[0]) {
-            case '/':
-               Ret = PKT_TYPE_CMD;
-               break;
-
-            case ILINK_DATA_PACKET:
-            // Data packet.  We only want to forward message line traffic, 
-            // not the general station info that we get when a new station 
-            // joins the conference.  The general form of message line traffic 
-            // is "callsign>data ..."  Check for "callsign>" at the begining of
-            // the line.
-
-            // Make sure this packet has an SSRC
-               Ret = PKT_TYPE_IGNORE;
-               cp = &p->Buf[sizeof(NDATA)];   // first character of data
-               if(*cp != '\r' && (cp1 = strchr(cp,'>')) != NULL) {
-                  *cp1 = 0;
-               // Make sure there are no spaces from the beginning of the line
-               // to the '>' and that the length of the callsign is reasonable
-                  Len = strlen(cp);
-                  if(Len <= MAX_CALL_LEN && strchr(cp,' ') == NULL) {
-                  // Yup, it's a message line
-                     Ret = PKT_TYPE_DATA;
-                     if(pCC->bCmdLine || strcmp(cp,pCC->Callsign) == 0) {
-                        if(!pCC->bCmdLine && 
-                           (cp1[1] == '.' || 
-                            strncmp(&cp1[1],"help\r",5) == 0 ||
-                            strncmp(&cp1[1],"HELP\r",5) == 0))
-                        {
-                           Ret = PKT_TYPE_CMD;
-                        }
-                     }
-                     else {
-                     // Callsign doesn't match.  Assume the client is a 
-                     // conference bridge because he's sending us text 
-                     // messages from other stations.
-                        pCC->bConf = TRUE;
-
-                        if(*cp == '*' || OurUser(pCS,cp)) {
-                        // Don't forward messages from our users or messages
-                        // from conference bridges to break loops.
-                        // Just ignore the packet
-                           Ret = PKT_TYPE_IGNORE;
-                        }
-                     }
-                  }
-                  *cp1 = '>';
-                  if(Ret != PKT_TYPE_CMD && !pCC->bCmdLine && 
-                     DuplicateTextMsg(p,pCC)) 
-                  {
-                     Ret = PKT_TYPE_IGNORE;
-                  }
-               }
-               
-               if(Ret == PKT_TYPE_IGNORE && !pCC->bFilePlayer) {
-                  if(pCC->bConf && *cp != '\r') {
-                  // Forward possible command response anyone who has
-                  // entered a quoted command
-                     ForwardCommandResponse(p,pCC);
-                  }
-                  else if(*cp == '\r') {
-                  // Must be the station's info text or station list
-                     Len = p->Count - strlen(NDATA) - 1;
-                     if(!pCC->bTBD) {
-                     // Only save brag sheet info if it's not relayed from 
-                     // another other conference
-                        if(pCC->Info != NULL) {
-                           free(pCC->Info);
-                        }
-                        pCC->Info = malloc(Len);
-                        if(pCC->Info != NULL) {
-                           memcpy(pCC->Info,cp,Len);
-                        }
-                     }
-
-                     if(SaveInfoFiles) {
-                     // Convert \r to \n
-                        cp1 = cp;
-                        while((cp1 = strchr(cp1,'\r')) != NULL) {
-                           *cp1++ = '\n';
-                        }
-
-                        CallLen = strlen(pCC->Callsign) + 1;   // include null
-                        cp1 = malloc(CallLen+strlen(INFO_EXTENSION));
-                        if(cp1 != NULL) {
-                           strcpy(cp1,pCC->Callsign);
-                           strcat(cp1,INFO_EXTENSION);
-                           Len = strlen(&cp[1]);
-                           if((fp = fopen(cp1,"w")) != NULL) {
-                              if(fwrite(&cp[1],Len,1,fp) != 1) {
-                              // Write error
-                                 LOG_ERROR(("GetPacketType(): fwrite failed, %s" 
-                                            ,Err2String(errno)));
-                              }
-                              fclose(fp);
-                           }
-                           free(cp1);
-                        }
-                     }
-                  }
-               }
-               break;
-
-            case ILINK_UNKNOWN_PACKET:
-               Ret = PKT_TYPE_IGNORE;
-               break;
-            
-            default:
-               if(pRTP->ssrc != 0) {
-               // Assume that he can handle a nonzero ssrc if he sends one
-                  pCC->bSendSSRC = TRUE;
-               }
-               Ret = PKT_TYPE_AUDIO;
-               break;
-         }
-         break;
-   }
-
-   if(Ret == PKT_TYPE_AUDIO && pCC->CompressionType != pCS->CompressionType) {
-   // It's audio, but not the compression type supported by this conference
-      DLOG(DLOG_CODEC_TYPE,("Ignoring CompressionType %d from %s.\n",
-           pCC->CompressionType,CallLog(pCC)));
-      Ret = PKT_TYPE_OTHER_AUDIO;
-   }
-
-   return Ret;
-}
-
-int FromUs(ClientInfo *p,ConfClient *pCC)
-{
-   rtp_hdr_t *pRTP = (rtp_hdr_t *) p->Buf;
-   int Ret = FALSE;
-
-   if(pCC->Proto == PROTO_ILINK || pCC->Proto == PROTO_RTP) {
-     if(pRTP->ssrc == OurNodeID && OurNodeID != 0) {
-        Ret = TRUE;
-     }
-   }
-
-   return Ret;
-}
-
-int CheckPassword(ConfClient *pCC,ACL_User *pACL)
-{
-   int Ret = FALSE;
-
-   if(pACL != NULL && *pACL->Password == '-') {
-   // User doesn't require a password 
       Ret = TRUE;
-   }
-   else if(pCC->Password != NULL && pACL != NULL) {
-   // User password set in ACL
-      if(strcmp(pACL->Password,pCC->Password) == 0) {
-      // User's password matches
-         Ret = TRUE;
-      }
-   }
-   else if(RTP_Pass != NULL) {
-   // Conference password set
-      if(strcmp(RTP_Pass,"-") == 0) {
-      // You asked for it, you got it ... no security for RTP / Speak Freely
-         Ret = TRUE;
-      }
-      else if(pCC->Password != NULL && strcmp(pCC->Password,RTP_Pass) == 0) {
-         Ret = TRUE;
-      }
-   }
+      break;
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-   return Ret;
+  return Ret;
 }
 
-// return: 
+void ForwardCommandResponse(ClientInfo *p, ConfClient *pCC1) {
+  ConfClient *pCC;
+  struct avl_traverser avl_trans;
+  ConfServer *pCS = pCC1->pCS;
+  char *cp = strdup(&p->Buf[sizeof(NDATA)]);
+
+  if (cp != NULL) {
+    p->Count = 0; // init for BufPrintf
+    BufPrintf(p, "%c" NDATA "%s>%s", ILINK_DATA_PACKET, pCC1->Callsign, cp);
+    free(cp);
+
+    // Forward all (remote) command responses to the command line client
+    // if he's in chat mode since he didn't need to use the .quote command
+    // to issue a command
+
+    if (bCmdLineChatMode) {
+      FwdTextCmdLine(p, p->Buf, &CmdLineCC);
+    }
+
+    if (ChatPort != 0) {
+      FwdTextCmdLine(p, p->Buf, &ChatCC);
+    }
+
+    pCC = &CmdLineCC;
+    while (pCC != NULL) {
+      if (pCC->bSentQuotedCmd) {
+        if (pCC == &CmdLineCC) {
+          if (!bCmdLineChatMode) {
+            FwdTextCmdLine(p, p->Buf, &CmdLineCC);
+          }
+        } else if (TimeLapse(&pCC->FirstAudioIn) > 30000) {
+          // Stop forwarding possible responses after 30 seconds
+          pCC->bSentQuotedCmd = FALSE;
+        } else {
+          Send2(pCC, p->Buf, p->Count, FALSE);
+          break;
+        }
+      }
+
+      if (pCC == &CmdLineCC) {
+        pCC = (ConfClient *)avl_t_first(&avl_trans, pCS->ConfTree);
+      } else {
+        pCC = (ConfClient *)avl_t_next(&avl_trans);
+      }
+    }
+  }
+}
+
+int DuplicateTextMsg(ClientInfo *p, ConfClient *pCC) {
+  int i;
+  int j;
+  unsigned short crc = 0;
+  int Ret = FALSE;
+  time_t Oldest = (time_t)-1;
+  int OldestEntry = 0;
+  DupTrackingEntry *pDup;
+  char *DupMessage;
+  char *cp;
+  ConfServer *pCS = pCC->pCS;
+  int TextLen = strlen(p->Buf);
+
+  // Calculate a CRC of the text message
+  // NB: exclude any SSRC appended to the message, there's a bug
+  // in some versions of EchoLink that caused the SSRC to be corrupted
+  // when text messages are forwarded.
+
+  for (i = 0; i < TextLen; i++) {
+    crc ^= p->Buf[i] << 8;
+    for (j = 0; j < 8; j++) {
+      if (crc & 0x8000) {
+        crc = crc << 1 ^ 0x1021;
+      } else {
+        crc <<= 1;
+      }
+    }
+  }
+
+  pDup = DupTracking;
+  for (i = 0; i < MAX_DUP_TRACKING; i++) {
+    if (Oldest == (time_t)-1 || pDup->TimeStamp < Oldest) {
+      Oldest = pDup->TimeStamp;
+      OldestEntry = i;
+    }
+
+    if ((TimeNow.tv_sec - pDup->TimeStamp) <= DUP_TRACKING_TIMEOUT &&
+        crc == pDup->crc) { // Duplicate!
+      pDup->TimeStamp = TimeNow.tv_sec;
+      if (!pDup->bLogged) {
+        pDup->bLogged = TRUE;
+        DupMessage = &p->Buf[sizeof(NDATA)];
+        if ((cp = strchr(DupMessage, '\r')) != NULL) {
+          // remove CR
+          *cp = 0;
+        }
+        LOG_WARN(("Dup from %s, %s dropped (0x%x):\n", pDup->FirstFrom,
+                  pCC->Callsign, pDup->crc));
+        LOG_WARN(("%s\n", DupMessage));
+
+        p->Count = 0; // init for BufPrintf
+        BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+        BufPrintf(p, "%s>Dup from %s, %s dropped.\r", ConferenceCall,
+                  pDup->FirstFrom, pCC->Callsign);
+        SendToAllSysops(p, pCS);
+      }
+      Ret = TRUE;
+      pCC->DupsReceived++;
+      pCS->DupsReceived++;
+      if (MaxDups != 0 && pCC->DupsReceived > MaxDups) {
+        pCS->DupDisconnects++;
+        LOG_ERROR(("Disconnecting %s too many dups.\n", pCC->Callsign));
+        DisconnectCC(p, pCC, "Loop disconnect!");
+
+        // We clobbered the buffer, reinitialize it for our response
+        p->Count = 0; // init for BufPrintf
+        BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+        BufPrintf(p, "%s disconnected, too many dups.\r", pCC->Callsign);
+        pCS->bSendStationList = TRUE;
+        SendToAllSysops(p, pCS);
+      }
+      break;
+    }
+    pDup++;
+  }
+
+  if (!Ret) {
+    // Add new text message to the cache
+    pDup = &DupTracking[OldestEntry];
+    if (pDup->TimeStamp != 0 &&
+        (TimeNow.tv_sec - pDup->TimeStamp) <= DUP_TRACKING_TIMEOUT) {
+      // Play it safe and assume this is a duplicate
+      Ret = TRUE;
+      LOG_WARN(("DupTracking cache full!\n"));
+      LOG_WARN(("Oldest: %d\n", OldestEntry));
+      for (i = 0; i < MAX_DUP_TRACKING; i++) {
+        LOG_WARN(("%d: TimeStamp: %d, From:%s, CRC: %d\n", i,
+                  DupTracking[i].TimeStamp, DupTracking[i].FirstFrom,
+                  DupTracking[i].crc));
+      }
+    }
+    pDup->crc = crc;
+    pDup->TimeStamp = TimeNow.tv_sec;
+    pDup->bLogged = FALSE;
+    strncpy(pDup->FirstFrom, pCC->Callsign, MAX_CALL_LEN);
+  }
+
+  return Ret;
+}
+
+PacketType GetPacketType(ClientInfo *p, ConfClient *pCC) {
+  char *cp;
+  char *cp1;
+  int Len;
+  soundbuf *pSFHdr = (soundbuf *)p->Buf;
+  rtp_hdr_t *pRTP = (rtp_hdr_t *)p->Buf;
+  ConfServer *pCS = pCC->pCS;
+  PacketType Ret = PKT_TYPE_UNKNOWN;
+  FILE *fp;
+  int CallLen;
+  int Compression;
+
+  switch (pCC->Proto) {
+  case PROTO_SF:
+    // Speak Freely sends text via the RTCP port, so if it's on the RTP
+    // port it must be audio
+    Compression = (int)ntohl(pSFHdr->compression);
+    if (Compression == (fCompGSM | fProtocol)) {
+      pCC->CompressionType = RTP_PT_GSM;
+      Ret = PKT_TYPE_AUDIO;
+    } else if (Compression == (fCompADPCM | fProtocol)) {
+      pCC->CompressionType = RTP_PT_DVI4_8K;
+      Ret = PKT_TYPE_AUDIO;
+    } else if (Compression == fProtocol) {
+      // No compression (uLaw)
+      pCC->CompressionType = RTP_PT_PCMU;
+      Ret = PKT_TYPE_AUDIO;
+    } else {
+      Ret = PKT_TYPE_IGNORE;
+      DLOG(DLOG_CODEC_TYPE, ("Ignoring SF CompressionType 0x%x from %s.\n",
+                             ntohl(pSFHdr->compression), CallLog(pCC)));
+    }
+    break;
+
+  case PROTO_RTP:
+    // RTP doesn't send text so it must be audio
+    pCC->bSendSSRC = TRUE; // always send ssrc for RTP
+    pCC->CompressionType = pRTP->pt;
+    switch (pRTP->pt) {
+    case RTP_PT_GSM:
+    case RTP_PT_DVI4_8K: // aka adpcm
+    case RTP_PT_PCMU:
+    case RTP_PT_G726:
+      Ret = PKT_TYPE_AUDIO;
+      break;
+
+    default:
+      Ret = PKT_TYPE_IGNORE;
+      DLOG(DLOG_CODEC_TYPE, ("Ignoring RTP packet type 0x%x from %s.\n",
+                             pRTP->pt, CallLog(pCC)));
+      break;
+    }
+    break;
+
+  case PROTO_ILINK:
+    switch (p->Buf[0]) {
+    case '/':
+      Ret = PKT_TYPE_CMD;
+      break;
+
+    case ILINK_DATA_PACKET:
+      // Data packet.  We only want to forward message line traffic,
+      // not the general station info that we get when a new station
+      // joins the conference.  The general form of message line traffic
+      // is "callsign>data ..."  Check for "callsign>" at the begining of
+      // the line.
+
+      // Make sure this packet has an SSRC
+      Ret = PKT_TYPE_IGNORE;
+      cp = &p->Buf[sizeof(NDATA)]; // first character of data
+      if (*cp != '\r' && (cp1 = strchr(cp, '>')) != NULL) {
+        *cp1 = 0;
+        // Make sure there are no spaces from the beginning of the line
+        // to the '>' and that the length of the callsign is reasonable
+        Len = strlen(cp);
+        if (Len <= MAX_CALL_LEN && strchr(cp, ' ') == NULL) {
+          // Yup, it's a message line
+          Ret = PKT_TYPE_DATA;
+          if (pCC->bCmdLine || strcmp(cp, pCC->Callsign) == 0) {
+            if (!pCC->bCmdLine &&
+                (cp1[1] == '.' || strncmp(&cp1[1], "help\r", 5) == 0 ||
+                 strncmp(&cp1[1], "HELP\r", 5) == 0)) {
+              Ret = PKT_TYPE_CMD;
+            }
+          } else {
+            // Callsign doesn't match.  Assume the client is a
+            // conference bridge because he's sending us text
+            // messages from other stations.
+            pCC->bConf = TRUE;
+
+            if (*cp == '*' || OurUser(pCS, cp)) {
+              // Don't forward messages from our users or messages
+              // from conference bridges to break loops.
+              // Just ignore the packet
+              Ret = PKT_TYPE_IGNORE;
+            }
+          }
+        }
+        *cp1 = '>';
+        if (Ret != PKT_TYPE_CMD && !pCC->bCmdLine && DuplicateTextMsg(p, pCC)) {
+          Ret = PKT_TYPE_IGNORE;
+        }
+      }
+
+      if (Ret == PKT_TYPE_IGNORE && !pCC->bFilePlayer) {
+        if (pCC->bConf && *cp != '\r') {
+          // Forward possible command response anyone who has
+          // entered a quoted command
+          ForwardCommandResponse(p, pCC);
+        } else if (*cp == '\r') {
+          // Must be the station's info text or station list
+          Len = p->Count - strlen(NDATA) - 1;
+          if (!pCC->bTBD) {
+            // Only save brag sheet info if it's not relayed from
+            // another other conference
+            if (pCC->Info != NULL) {
+              free(pCC->Info);
+            }
+            pCC->Info = malloc(Len);
+            if (pCC->Info != NULL) {
+              memcpy(pCC->Info, cp, Len);
+            }
+          }
+
+          if (SaveInfoFiles) {
+            // Convert \r to \n
+            cp1 = cp;
+            while ((cp1 = strchr(cp1, '\r')) != NULL) {
+              *cp1++ = '\n';
+            }
+
+            CallLen = strlen(pCC->Callsign) + 1; // include null
+            cp1 = malloc(CallLen + strlen(INFO_EXTENSION));
+            if (cp1 != NULL) {
+              strcpy(cp1, pCC->Callsign);
+              strcat(cp1, INFO_EXTENSION);
+              Len = strlen(&cp[1]);
+              if ((fp = fopen(cp1, "w")) != NULL) {
+                if (fwrite(&cp[1], Len, 1, fp) != 1) {
+                  // Write error
+                  LOG_ERROR(("GetPacketType(): fwrite failed, %s",
+                             Err2String(errno)));
+                }
+                fclose(fp);
+              }
+              free(cp1);
+            }
+          }
+        }
+      }
+      break;
+
+    case ILINK_UNKNOWN_PACKET:
+      Ret = PKT_TYPE_IGNORE;
+      break;
+
+    default:
+      if (pRTP->ssrc != 0) {
+        // Assume that he can handle a nonzero ssrc if he sends one
+        pCC->bSendSSRC = TRUE;
+      }
+      Ret = PKT_TYPE_AUDIO;
+      break;
+    }
+    break;
+  }
+
+  if (Ret == PKT_TYPE_AUDIO && pCC->CompressionType != pCS->CompressionType) {
+    // It's audio, but not the compression type supported by this conference
+    DLOG(DLOG_CODEC_TYPE, ("Ignoring CompressionType %d from %s.\n",
+                           pCC->CompressionType, CallLog(pCC)));
+    Ret = PKT_TYPE_OTHER_AUDIO;
+  }
+
+  return Ret;
+}
+
+int FromUs(ClientInfo *p, ConfClient *pCC) {
+  rtp_hdr_t *pRTP = (rtp_hdr_t *)p->Buf;
+  int Ret = FALSE;
+
+  if (pCC->Proto == PROTO_ILINK || pCC->Proto == PROTO_RTP) {
+    if (pRTP->ssrc == OurNodeID && OurNodeID != 0) {
+      Ret = TRUE;
+    }
+  }
+
+  return Ret;
+}
+
+int CheckPassword(ConfClient *pCC, ACL_User *pACL) {
+  int Ret = FALSE;
+
+  if (pACL != NULL && *pACL->Password == '-') {
+    // User doesn't require a password
+    Ret = TRUE;
+  } else if (pCC->Password != NULL && pACL != NULL) {
+    // User password set in ACL
+    if (strcmp(pACL->Password, pCC->Password) == 0) {
+      // User's password matches
+      Ret = TRUE;
+    }
+  } else if (RTP_Pass != NULL) {
+    // Conference password set
+    if (strcmp(RTP_Pass, "-") == 0) {
+      // You asked for it, you got it ... no security for RTP / Speak Freely
+      Ret = TRUE;
+    } else if (pCC->Password != NULL && strcmp(pCC->Password, RTP_Pass) == 0) {
+      Ret = TRUE;
+    }
+  }
+
+  return Ret;
+}
+
+// return:
 //    0 - Client is not authorized
 //    1 - Client is authorized
-//    2 - Don't know yet. (Unknown EchoLink client, checking with 
+//    2 - Don't know yet. (Unknown EchoLink client, checking with
 //        directory server).
-int AuthorizedClient(ClientInfo *p,ConfClient *pCC)
-{
-   UserInfo UserLookup;
-   UserInfo *pUser;
-   ACL_User *pACL;
-   ACL_User *pACL1;
-   ACL_User ACL_Lookup;
-   char *Dash;
-   int Authorized = 0;
-   int bAllowUnknown = FALSE;
-   char Temp[32];
-   char *BaseCall = strdup(pCC->Callsign);
+int AuthorizedClient(ClientInfo *p, ConfClient *pCC) {
+  UserInfo UserLookup;
+  UserInfo *pUser;
+  ACL_User *pACL;
+  ACL_User *pACL1;
+  ACL_User ACL_Lookup;
+  char *Dash;
+  int Authorized = 0;
+  int bAllowUnknown = FALSE;
+  char Temp[32];
+  char *BaseCall = strdup(pCC->Callsign);
 
-   UserLookup.Callsign = pCC->Callsign;
-   ACL_Lookup.Callsign = BaseCall;
-   ACL_Lookup.HisAdr.ADDR = pCC->HisAdr.ADDR;
+  UserLookup.Callsign = pCC->Callsign;
+  ACL_Lookup.Callsign = BaseCall;
+  ACL_Lookup.HisAdr.ADDR = pCC->HisAdr.ADDR;
 
-   if((Dash = strchr(BaseCall,'-')) != NULL) {
-      *Dash = 0;
-   }
+  if ((Dash = strchr(BaseCall, '-')) != NULL) {
+    *Dash = 0;
+  }
 
-   if((pUser = avl_find(UserTree,&UserLookup)) != NULL) {
-   // user is in directory, set his mute flag
-      if(pUser->bMuted) {
-         pCC->bMuted = TRUE;
-      }
-      
-      if(pUser->bUnMuted) {
-         pCC->bMuted = FALSE;
-      }
+  if ((pUser = avl_find(UserTree, &UserLookup)) != NULL) {
+    // user is in directory, set his mute flag
+    if (pUser->bMuted) {
+      pCC->bMuted = TRUE;
+    }
 
-      if(pUser->bChatMuted) {
-         pCC->bMuteChat = TRUE;
-      }
-      
-      if(pUser->bChatUnMuted) {
-         pCC->bMuteChat = FALSE;
-      }
-   }
+    if (pUser->bUnMuted) {
+      pCC->bMuted = FALSE;
+    }
 
-   if(RTP_Pass != NULL && strcmp(RTP_Pass,"!") == 0) {
-   // You asked for it, you got it ... hardly any security at all !
-      bAllowUnknown = TRUE;
-   }
-   
-   if(pCC->Proto == PROTO_ILINK) {
-   // Lookup EchoLink clients by callsign and check the IP address
-      pACL = avl_find(ACL_Call_Tree,&ACL_Lookup);
+    if (pUser->bChatMuted) {
+      pCC->bMuteChat = TRUE;
+    }
 
-      if(pACL != NULL && !pACL->bAuthorized) {
+    if (pUser->bChatUnMuted) {
+      pCC->bMuteChat = FALSE;
+    }
+  }
+
+  if (RTP_Pass != NULL && strcmp(RTP_Pass, "!") == 0) {
+    // You asked for it, you got it ... hardly any security at all !
+    bAllowUnknown = TRUE;
+  }
+
+  if (pCC->Proto == PROTO_ILINK) {
+    // Lookup EchoLink clients by callsign and check the IP address
+    pACL = avl_find(ACL_Call_Tree, &ACL_Lookup);
+
+    if (pACL != NULL && !pACL->bAuthorized) {
       // Banned client, ignore the turkey
-      }
-      else if((pACL1 = avl_find(ACL_IP_Tree,&ACL_Lookup)) != NULL) {
+    } else if ((pACL1 = avl_find(ACL_IP_Tree, &ACL_Lookup)) != NULL) {
       // Client's IP address is in ACL
-         if(pACL1->bAuthorized) {
-         // Client Allowed by IP address
-            Authorized = 1;
-            LOG_NORM(("%s allowed by IP/hostname address %s/%s.\n",
-                      pCC->Callsign,inet_ntoa(pACL1->HisAdr.i.sin_addr),
-                      pACL1->HostName));
-         }
-         else {
-         // Client Banned by IP address, ignore the turkey
-            LOG_NORM(("%s banned IP/hostname address %s/%s.\n",
-                      pCC->Callsign,inet_ntoa(pACL1->HisAdr.i.sin_addr),
-                      pACL1->HostName));
-         }
+      if (pACL1->bAuthorized) {
+        // Client Allowed by IP address
+        Authorized = 1;
+        LOG_NORM(("%s allowed by IP/hostname address %s/%s.\n", pCC->Callsign,
+                  inet_ntoa(pACL1->HisAdr.i.sin_addr), pACL1->HostName));
+      } else {
+        // Client Banned by IP address, ignore the turkey
+        LOG_NORM(("%s banned IP/hostname address %s/%s.\n", pCC->Callsign,
+                  inet_ntoa(pACL1->HisAdr.i.sin_addr), pACL1->HostName));
       }
-      else if(bAllowUnknown || (bQuickStart && ActiveDirEntries == 0)) {
+    } else if (bAllowUnknown || (bQuickStart && ActiveDirEntries == 0)) {
       // Allow anyone that's not specifically banned
-         Authorized = 1;
-      }
-      else if(pUser != NULL) {
+      Authorized = 1;
+    } else if (pUser != NULL) {
       // client found in directory
-         if(pUser->HisAdr.ADDR == pCC->HisAdr.ADDR) {
-         // IP address matches
-            if(PrivateConference) {
-               if(pACL != NULL) {
-                  Authorized = pACL->bAuthorized ? 1 : 0;
-               }
-            }
-            else {
-               Authorized = pUser->bAuthorized ? 1 : 0;
-            }
-         }
-         else {
-         // IP address mismatch
-            strcpy(Temp,inet_ntoa(pCC->HisAdr.i.sin_addr));
-            LOG_NORM(("Rejecting %s, dir IP %s != IP %s.\n",
-                      pCC->Callsign,inet_ntoa(pUser->HisAdr.i.sin_addr),Temp));
-         // Perhaps he has a dynamic IP address and has a difference IP
-         // address than he did when we last refreshed the list, check
-         // with the directory server and see.
-            if(LoginInterval > 0) {
-               ValidateCallsign(pCC->Callsign,&pCC->HisAdr);
-            }
-            EchoLinkIPCompareFailures++;
-         }
+      if (pUser->HisAdr.ADDR == pCC->HisAdr.ADDR) {
+        // IP address matches
+        if (PrivateConference) {
+          if (pACL != NULL) {
+            Authorized = pACL->bAuthorized ? 1 : 0;
+          }
+        } else {
+          Authorized = pUser->bAuthorized ? 1 : 0;
+        }
+      } else {
+        // IP address mismatch
+        strcpy(Temp, inet_ntoa(pCC->HisAdr.i.sin_addr));
+        LOG_NORM(("Rejecting %s, dir IP %s != IP %s.\n", pCC->Callsign,
+                  inet_ntoa(pUser->HisAdr.i.sin_addr), Temp));
+        // Perhaps he has a dynamic IP address and has a difference IP
+        // address than he did when we last refreshed the list, check
+        // with the directory server and see.
+        if (LoginInterval > 0) {
+          ValidateCallsign(pCC->Callsign, &pCC->HisAdr);
+        }
+        EchoLinkIPCompareFailures++;
       }
-      else if(pACL != NULL) {
+    } else if (pACL != NULL) {
       // client not in directory, but in ACL and not banned
-         if(*pACL->HostName == '-' ) {
-         // allowed client with any IP address
-            Authorized = 1;
-            LOG_WARN(("Accepted %s %s without IP address check.\n",
-                      pCC->Callsign,inet_ntoa(pCC->HisAdr.i.sin_addr)));
-         }
-         else if(pCC->HisAdr.ADDR == pACL->HisAdr.ADDR) {
-            Authorized = 1;
-         }
+      if (*pACL->HostName == '-') {
+        // allowed client with any IP address
+        Authorized = 1;
+        LOG_WARN(("Accepted %s %s without IP address check.\n", pCC->Callsign,
+                  inet_ntoa(pCC->HisAdr.i.sin_addr)));
+      } else if (pCC->HisAdr.ADDR == pACL->HisAdr.ADDR) {
+        Authorized = 1;
       }
-      else {
-      // User is not in our ACL or in the directory server's list currently, 
+    } else {
+      // User is not in our ACL or in the directory server's list currently,
       // ask server about him specifically.
-         LOG_NORM(("%s not found in directory.\n",pCC->Callsign));
-         if(iLinkDirServer) {
-         // The iLink server doesn't support individual callsign validation,
-         // just refresh the entire directory list
-            NextLoginTime = TimeNow.tv_sec + LoginInterval;
-            NextStationListTime = TimeNow.tv_sec + StationListInterval;
-            ServerRequest(SERV_REQ_LOGIN_AND_LIST,0,NULL);
-         }
-         else if(LoginInterval > 0) {
-            Authorized = 2;      // Don't know yet
-            ValidateCallsign(pCC->Callsign,&pCC->HisAdr);
-         }
+      LOG_NORM(("%s not found in directory.\n", pCC->Callsign));
+      if (iLinkDirServer) {
+        // The iLink server doesn't support individual callsign validation,
+        // just refresh the entire directory list
+        NextLoginTime = TimeNow.tv_sec + LoginInterval;
+        NextStationListTime = TimeNow.tv_sec + StationListInterval;
+        ServerRequest(SERV_REQ_LOGIN_AND_LIST, 0, NULL);
+      } else if (LoginInterval > 0) {
+        Authorized = 2; // Don't know yet
+        ValidateCallsign(pCC->Callsign, &pCC->HisAdr);
       }
+    }
 
-      if(Authorized == 0) {
-         EchoAuthenticationFailures++;
-      }
-   }
-   else {
-   // RTP / Speak Freely client
-      if((pACL = avl_find(ACL_IP_Tree,&ACL_Lookup)) != NULL) {
+    if (Authorized == 0) {
+      EchoAuthenticationFailures++;
+    }
+  } else {
+    // RTP / Speak Freely client
+    if ((pACL = avl_find(ACL_IP_Tree, &ACL_Lookup)) != NULL) {
       // Found IP address or hostname match
-         if(pACL->bAuthorized && CheckPassword(pCC,pACL)) {
-            Authorized = 1;
-            if(avl_find(ACL_Call_Tree,&ACL_Lookup) == NULL) {
-            // Didn't find a match on the callsign so RTCP didn't have 
-            // callsign info Get it from the ACL list
+      if (pACL->bAuthorized && CheckPassword(pCC, pACL)) {
+        Authorized = 1;
+        if (avl_find(ACL_Call_Tree, &ACL_Lookup) == NULL) {
+          // Didn't find a match on the callsign so RTCP didn't have
+          // callsign info Get it from the ACL list
 
-               if(pCC->Callsign != NULL) {
-                  free(pCC->Callsign);
-               }
-               if(pCC->CallPlus != NULL) {
-                  free(pCC->CallPlus);
-               }
-   
-               pCC->CallPlus = strdup(pACL->CallPlus);
-               pCC->Callsign = strdup(pACL->Callsign);
-            }
-         }
+          if (pCC->Callsign != NULL) {
+            free(pCC->Callsign);
+          }
+          if (pCC->CallPlus != NULL) {
+            free(pCC->CallPlus);
+          }
+
+          pCC->CallPlus = strdup(pACL->CallPlus);
+          pCC->Callsign = strdup(pACL->Callsign);
+        }
       }
-      else if((pACL = avl_find(ACL_Call_Tree,&ACL_Lookup)) != NULL) {
+    } else if ((pACL = avl_find(ACL_Call_Tree, &ACL_Lookup)) != NULL) {
       // Found callsign match
-         if(pACL->bAuthorized && *pACL->HostName == '-' && 
-            CheckPassword(pCC,pACL))
-         {
-            Authorized = 1;
-         }
+      if (pACL->bAuthorized && *pACL->HostName == '-' &&
+          CheckPassword(pCC, pACL)) {
+        Authorized = 1;
       }
-      else if(CheckPassword(pCC,NULL)) {
+    } else if (CheckPassword(pCC, NULL)) {
       // Conference bridge password match
-         Authorized = 1;
-      }
-      else if(bAllowUnknown) {
+      Authorized = 1;
+    } else if (bAllowUnknown) {
       // Allow anyone that's not specifically banned
-         Authorized = 1;
-      }
-      else {
+      Authorized = 1;
+    } else {
       // No thanks !
-         p->Count = 0;  // init for BufPrintf
-         BufPrintf(p,"%c" NDATA,ILINK_DATA_PACKET);
-         BufPrintf(p,"Unauthorized connect request from %s.",
-                  inet_ntoa(pCC->HisAdr.i.sin_addr));
-         SendToAllSysops(p,pCC->pCS);
-      }
+      p->Count = 0; // init for BufPrintf
+      BufPrintf(p, "%c" NDATA, ILINK_DATA_PACKET);
+      BufPrintf(p, "Unauthorized connect request from %s.",
+                inet_ntoa(pCC->HisAdr.i.sin_addr));
+      SendToAllSysops(p, pCC->pCS);
+    }
 
-      if(Authorized == 0) {
-         AuthenticationFailures++;
-      }
-   }
+    if (Authorized == 0) {
+      AuthenticationFailures++;
+    }
+  }
 
-   if(BaseCall != NULL) {
-      free(BaseCall);
-   }
+  if (BaseCall != NULL) {
+    free(BaseCall);
+  }
 
-   return Authorized;
+  return Authorized;
 }
 
-void SaveBadPacket(ClientInfo *p,char *Filename)
-{
-   FILE *fp = fopen(Filename,"w");
+void SaveBadPacket(ClientInfo *p, char *Filename) {
+  FILE *fp = fopen(Filename, "w");
 
-   if(fp != NULL) {
-      if(fwrite(p->Buf,p->Count,1,fp) != 1) {
-         LOG_ERROR(("SaveBadPacket(): fwrite failed, %s",Err2String(errno)));
-      }
-      fclose(fp);
-   }
-   else {
-      LOG_ERROR(("SaveBadPacket(): fopen failed, %s",Err2String(errno)));
-   }
+  if (fp != NULL) {
+    if (fwrite(p->Buf, p->Count, 1, fp) != 1) {
+      LOG_ERROR(("SaveBadPacket(): fwrite failed, %s", Err2String(errno)));
+    }
+    fclose(fp);
+  } else {
+    LOG_ERROR(("SaveBadPacket(): fopen failed, %s", Err2String(errno)));
+  }
 }
 
-void SendAvrsUpdate(AVRS_State State,char *Callsign)
-{
-   char TempSDES[512];
-   int   Len = 0;
-   IPAdrUnion HisAdr;
-   struct hostent *pHost;
-   int Sent;
+void SendAvrsUpdate(AVRS_State State, char *Callsign) {
+  char TempSDES[512];
+  int Len = 0;
+  IPAdrUnion HisAdr;
+  struct hostent *pHost;
+  int Sent;
 
-   if(AvrsEnable && LoginInterval > 0) {
-      Len = CreateAvrsPacket(State,Callsign,TempSDES,sizeof(TempSDES));
-   }
+  if (AvrsEnable && LoginInterval > 0) {
+    Len = CreateAvrsPacket(State, Callsign, TempSDES, sizeof(TempSDES));
+  }
 
-   if(Len > 0) {
-      pHost = GetHostByName("aprs.echolink.org");
-      if(pHost != NULL) {
-         HisAdr.i.sin_addr.s_addr = IP_FROM_HOSTENT(pHost,0);
-         HisAdr.i.sin_family = AF_INET;
-         HisAdr.PORT = htons(ILINK_RTCP_PORT);
-         Sent = sendto(piLinkConf->pControl->Socket,TempSDES,Len,0,&HisAdr.s,
-                       sizeof(HisAdr));
-         if(Sent != Len) {
-            LOG_ERROR(("SendAvrsUpdate: sendto failed, %s",Err2String(errno)));
-         }
+  if (Len > 0) {
+    pHost = GetHostByName("aprs.echolink.org");
+    if (pHost != NULL) {
+      HisAdr.i.sin_addr.s_addr = IP_FROM_HOSTENT(pHost, 0);
+      HisAdr.i.sin_family = AF_INET;
+      HisAdr.PORT = htons(ILINK_RTCP_PORT);
+      Sent = sendto(piLinkConf->pControl->Socket, TempSDES, Len, 0, &HisAdr.s,
+                    sizeof(HisAdr));
+      if (Sent != Len) {
+        LOG_ERROR(("SendAvrsUpdate: sendto failed, %s", Err2String(errno)));
       }
-   }
+    }
+  }
 }
 
 // Begin K1RFD 1/30/08
-void SendFirewallOpenRequest(ConfServer *pCS, ConfClient *pCC)
-{
-    // Send an OPEN request to the specified peer via the addressing
-    // server.  We do this each time we want to establish a connection,
-    // in case the recipient of the connection request is behind an
-    // unconfigured NAT firewall.  His software has already established
-    // a "flow" with the addressing server, so the addressing server
-    // should be able to relay this request to him successfully.  When
-    // he receives it, he responds by sending us a set of packets through
-    // his firewall, which establishes the necessary flow in his firewall
-    // for a QSO between us to take place.
+void SendFirewallOpenRequest(ConfServer *pCS, ConfClient *pCC) {
+  // Send an OPEN request to the specified peer via the addressing
+  // server.  We do this each time we want to establish a connection,
+  // in case the recipient of the connection request is behind an
+  // unconfigured NAT firewall.  His software has already established
+  // a "flow" with the addressing server, so the addressing server
+  // should be able to relay this request to him successfully.  When
+  // he receives it, he responds by sending us a set of packets through
+  // his firewall, which establishes the necessary flow in his firewall
+  // for a QSO between us to take place.
 
-    // The OPEN request is in the SDES portion of an RTCP packet.
-    // The fields are as follows:
-    //     CNAME: callsign of the originating node (us)
-    //     LOC:   "OPEN"
-    //     EMAIL: dotted ip address of the destination node (him)
+  // The OPEN request is in the SDES portion of an RTCP packet.
+  // The fields are as follows:
+  //     CNAME: callsign of the originating node (us)
+  //     LOC:   "OPEN"
+  //     EMAIL: dotted ip address of the destination node (him)
 
-    int rtp_version = ILINK_RTP_VERSION;
-    char *pFirstData;
-    int PadCount;
-    ConfClient cc;
-    int Server = 0;  // for now
-    char *DestNodeDottedIP;
-    struct hostent *pTemp;
-    char OurSDES[512];
-    int SDESLen;
+  int rtp_version = ILINK_RTP_VERSION;
+  char *pFirstData;
+  int PadCount;
+  ConfClient cc;
+  int Server = 0; // for now
+  char *DestNodeDottedIP;
+  struct hostent *pTemp;
+  char OurSDES[512];
+  int SDESLen;
 
-    union {
-      char *cp;
-      rtcp_t *p;
-    } u;
+  union {
+    char *cp;
+    rtcp_t *p;
+  } u;
 
-    union {
-      char *cp;
-      rtcp_sdes_item_t *p;
-    } Item;
+  union {
+    char *cp;
+    rtcp_sdes_item_t *p;
+  } Item;
 
+  DestNodeDottedIP = inet_ntoa(pCC->HisAdr.i.sin_addr);
 
-    DestNodeDottedIP = inet_ntoa(pCC->HisAdr.i.sin_addr);
+  u.cp = OurSDES;
 
-    u.cp = OurSDES;
+  u.p->common.version = rtp_version;
+  u.p->common.p = 0;
+  u.p->common.count = 0;
+  u.p->common.pt = RTCP_RR;
+  u.p->common.length = htons(1);
+  u.p->r.rr.ssrc = OurNodeID;
 
-    u.p->common.version = rtp_version;
-    u.p->common.p = 0;
-    u.p->common.count = 0;
-    u.p->common.pt = RTCP_RR;
-    u.p->common.length = htons(1);
-    u.p->r.rr.ssrc = OurNodeID;
+  u.cp += sizeof(u.p->common) + sizeof(u.p->r.rr.ssrc);
+  u.p->common.version = rtp_version;
+  u.p->common.p = 1;
+  u.p->common.count = 1;
+  u.p->common.pt = RTCP_SDES;
 
-    u.cp += sizeof(u.p->common) + sizeof(u.p->r.rr.ssrc);
-    u.p->common.version = rtp_version;
+  u.p->r.sdes.src = OurNodeID;
+  pFirstData = (char *)&u.p->r.sdes.src;
+
+  Item.p = &u.p->r.sdes.item[0];
+  Item.p->type = RTCP_SDES_CNAME;
+  Item.p->length = (u_int8)strlen(ConferenceCall);
+  memcpy(Item.p->data, ConferenceCall, Item.p->length);
+
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  Item.p->type = RTCP_SDES_LOC;
+  Item.p->length = (u_int8)strlen("OPEN");
+  memcpy(Item.p->data, "OPEN", Item.p->length);
+
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  Item.p->type = RTCP_SDES_EMAIL;
+  Item.p->length = (u_int8)strlen(DestNodeDottedIP);
+  memcpy(Item.p->data, DestNodeDottedIP, Item.p->length);
+
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+  Item.p->type = RTCP_SDES_END;
+  Item.p->length = 0;
+  Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
+
+  PadCount = 4 - ((Item.cp - pFirstData) % 4);
+
+  if (PadCount > 0 && PadCount < 4) {
+    // Padding is needed
     u.p->common.p = 1;
-    u.p->common.count = 1;
-    u.p->common.pt = RTCP_SDES;
-
-    u.p->r.sdes.src = OurNodeID;
-    pFirstData = (char *) &u.p->r.sdes.src;
-
-    Item.p = &u.p->r.sdes.item[0];
-    Item.p->type = RTCP_SDES_CNAME;
-    Item.p->length = (u_int8) strlen(ConferenceCall);
-    memcpy(Item.p->data,ConferenceCall,Item.p->length);
-
-    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-    Item.p->type = RTCP_SDES_LOC;
-    Item.p->length = (u_int8) strlen("OPEN");
-    memcpy(Item.p->data,"OPEN",Item.p->length);
-
-    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-    Item.p->type = RTCP_SDES_EMAIL;
-    Item.p->length = (u_int8) strlen(DestNodeDottedIP);
-    memcpy(Item.p->data,DestNodeDottedIP,Item.p->length);
-
-    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-    Item.p->type = RTCP_SDES_END;
-    Item.p->length = 0;
-    Item.cp = Item.cp + sizeof(rtcp_sdes_item_t) + Item.p->length - 1;
-
-    PadCount = 4 - ((Item.cp - pFirstData) % 4);
-
-    if(PadCount > 0 && PadCount < 4) {
-        // Padding is needed
-        u.p->common.p = 1;
-        if(PadCount > 1) {
-            memset(Item.cp,0,PadCount-1);
-        }
-        Item.cp[PadCount-1] = PadCount;
-        Item.cp += PadCount;
-    } else {
-        // No padding needed
-        u.p->common.p = 0;
+    if (PadCount > 1) {
+      memset(Item.cp, 0, PadCount - 1);
     }
-    u.p->common.length = htons((u_short) ((Item.cp - pFirstData)/4));
-    SDESLen = Item.cp - OurSDES;
+    Item.cp[PadCount - 1] = PadCount;
+    Item.cp += PadCount;
+  } else {
+    // No padding needed
+    u.p->common.p = 0;
+  }
+  u.p->common.length = htons((u_short)((Item.cp - pFirstData) / 4));
+  SDESLen = Item.cp - OurSDES;
 
-    // Construct a "client" structure for the addressing server.
-    // Note that Send2() needs the pCS member.
-    memset(&cc, 0, sizeof(cc));
-    cc.pCS = pCS;
-    cc.HisAdr.i.sin_family = AF_INET;
-    cc.HisAdr.i.sin_port = ILINK_RTCP_PORT;
+  // Construct a "client" structure for the addressing server.
+  // Note that Send2() needs the pCS member.
+  memset(&cc, 0, sizeof(cc));
+  cc.pCS = pCS;
+  cc.HisAdr.i.sin_family = AF_INET;
+  cc.HisAdr.i.sin_port = ILINK_RTCP_PORT;
 
-    // TODO: We really should send this packet to the same addressing
-    // server we are currently using, rather than the first one in 
-    // the list, in case the first one in the list is offline.  However,
-    // aside from that, it makes no difference which one we send it to
-    // since they all relay these packets to one another.
-    if (Server >= NUM_DIRECTORY_SERVERS || DirServerHost[Server] == NULL)
-        Server = 0;
+  // TODO: We really should send this packet to the same addressing
+  // server we are currently using, rather than the first one in
+  // the list, in case the first one in the list is offline.  However,
+  // aside from that, it makes no difference which one we send it to
+  // since they all relay these packets to one another.
+  if (Server >= NUM_DIRECTORY_SERVERS || DirServerHost[Server] == NULL)
+    Server = 0;
 
-    // Apropos of the note above, if we keep track of the current addressing
-    // server's Internet address, we can avoid this DNS lookup here.
-    pTemp = GetHostByName(DirServerHost[Server]);
-    if(pTemp != NULL) {
-        cc.HisAdr.i.sin_addr.s_addr = IP_FROM_HOSTENT(pTemp,0);
-    } else {
-        cc.HisAdr.i.sin_addr.s_addr = inet_addr(DirServerHost[Server]);
-    }
+  // Apropos of the note above, if we keep track of the current addressing
+  // server's Internet address, we can avoid this DNS lookup here.
+  pTemp = GetHostByName(DirServerHost[Server]);
+  if (pTemp != NULL) {
+    cc.HisAdr.i.sin_addr.s_addr = IP_FROM_HOSTENT(pTemp, 0);
+  } else {
+    cc.HisAdr.i.sin_addr.s_addr = inet_addr(DirServerHost[Server]);
+  }
 
-    Send2(&cc,OurSDES,SDESLen,TRUE);
-    D2PRINTF(("Sent firewall OPEN request to %s via %s\n", DestNodeDottedIP, 
-              DirServerHost[Server]));
+  Send2(&cc, OurSDES, SDESLen, TRUE);
+  D2PRINTF(("Sent firewall OPEN request to %s via %s\n", DestNodeDottedIP,
+            DirServerHost[Server]));
 }
 // End K1RFD 1/30/08
-
 
 // Update ConnectedStatus to reflect current connection status.
 // "real" conferences take precedence over "normal" nodes running as
 // conferences which take precedence over "normal" nodes.
-void UpdateConnectedStatus()
-{
-   struct avl_traverser avl_trans;
-   ConfClient *pCC = NULL;
-   char *TempRealConf = NULL;
-   char *TempConf = NULL;
-   char *TempStation = NULL;
-   int bCurrentTopStation;
-   
-   pCC = (ConfClient *) avl_t_first(&avl_trans,piLinkConf->ConfTree);
-   while(pCC != NULL) {
-      if(pCC->bInConf) {
+void UpdateConnectedStatus() {
+  struct avl_traverser avl_trans;
+  ConfClient *pCC = NULL;
+  char *TempRealConf = NULL;
+  char *TempConf = NULL;
+  char *TempStation = NULL;
+  int bCurrentTopStation;
+
+  pCC = (ConfClient *)avl_t_first(&avl_trans, piLinkConf->ConfTree);
+  while (pCC != NULL) {
+    if (pCC->bInConf) {
       // This is an active connection
-         bCurrentTopStation = strcmp(ConnectedStatus,pCC->Callsign) == 0;
-         if(pCC->bConf) {
-         // This client is a conference
-            if(pCC->Callsign[0] == '*') {
-            // And it's a "real" conference
-               if(bCurrentTopStation || TempRealConf == NULL) {
-                  TempRealConf = pCC->Callsign;
-               }
-            }
-            else {
-            // Not a "real" conference but better than nothing
-               if(bCurrentTopStation || TempConf == NULL) {
-                  TempConf = pCC->Callsign;
-               }
-            }
-         }
-         else if(ShowStatusInInfo == 2) {
-            if(bCurrentTopStation || TempStation == NULL) {
-               TempStation = pCC->Callsign;
-            }
-         }
+      bCurrentTopStation = strcmp(ConnectedStatus, pCC->Callsign) == 0;
+      if (pCC->bConf) {
+        // This client is a conference
+        if (pCC->Callsign[0] == '*') {
+          // And it's a "real" conference
+          if (bCurrentTopStation || TempRealConf == NULL) {
+            TempRealConf = pCC->Callsign;
+          }
+        } else {
+          // Not a "real" conference but better than nothing
+          if (bCurrentTopStation || TempConf == NULL) {
+            TempConf = pCC->Callsign;
+          }
+        }
+      } else if (ShowStatusInInfo == 2) {
+        if (bCurrentTopStation || TempStation == NULL) {
+          TempStation = pCC->Callsign;
+        }
       }
-      pCC = (ConfClient *) avl_t_next(&avl_trans);
-   }
+    }
+    pCC = (ConfClient *)avl_t_next(&avl_trans);
+  }
 
-   if(TempRealConf != NULL) {
-      TempConf = TempRealConf;
-   }
+  if (TempRealConf != NULL) {
+    TempConf = TempRealConf;
+  }
 
-   if(TempConf != NULL) {
-      snprintf(ConnectedStatus,sizeof(ConnectedStatus),"In Conference %s",
-               TempConf);
-   }
-   else if(TempStation != NULL) {
-      snprintf(ConnectedStatus,sizeof(ConnectedStatus),"Connected to %s",
-               TempStation);
-   }
-   else {
-      ConnectedStatus[0] = 0;
-   }
+  if (TempConf != NULL) {
+    snprintf(ConnectedStatus, sizeof(ConnectedStatus), "In Conference %s",
+             TempConf);
+  } else if (TempStation != NULL) {
+    snprintf(ConnectedStatus, sizeof(ConnectedStatus), "Connected to %s",
+             TempStation);
+  } else {
+    ConnectedStatus[0] = 0;
+  }
 }
 
 // Return pointer to first character of the user's chat text
 // Follows CALLSIGN>
-char *FirstChatChar(char *Buf)
-{
-   char *cp;
-   char *cp1;
-   char *Ret = NULL;
-   int Len;
+char *FirstChatChar(char *Buf) {
+  char *cp;
+  char *cp1;
+  char *Ret = NULL;
+  int Len;
 
-   cp = &Buf[sizeof(NDATA)];   // first character of data
-   if(*cp != '\r' && (cp1 = strchr(cp,'>')) != NULL) {
-      *cp1 = 0;
-   // Make sure there are no spaces from the beginning of the line
-   // to the '>' and that the length of the callsign is reasonable
-      Len = strlen(cp);
-      if(Len <= MAX_CALL_LEN && strchr(cp,' ') == NULL) {
+  cp = &Buf[sizeof(NDATA)]; // first character of data
+  if (*cp != '\r' && (cp1 = strchr(cp, '>')) != NULL) {
+    *cp1 = 0;
+    // Make sure there are no spaces from the beginning of the line
+    // to the '>' and that the length of the callsign is reasonable
+    Len = strlen(cp);
+    if (Len <= MAX_CALL_LEN && strchr(cp, ' ') == NULL) {
       // Yup, looks like a chat line all right
-         Ret = &cp1[1];
-      }
-      *cp1 = '>';
-   }
-   return Ret;
+      Ret = &cp1[1];
+    }
+    *cp1 = '>';
+  }
+  return Ret;
 }
 
-void ConferenceCleanup()
-{
-   struct avl_traverser avl_trans;
-   ConfServer *pCS;
-   ConfServer *pNextCS;
+void ConferenceCleanup() {
+  struct avl_traverser avl_trans;
+  ConfServer *pCS;
+  ConfServer *pNextCS;
 
-   pNextCS = (ConfServer *) avl_t_first(&avl_trans,Conferences);
-   while((pCS = pNextCS) != NULL) {
-      pNextCS = (ConfServer *) avl_t_next(&avl_trans);
-      DeleteConf(pCS);
-   }
-   avl_destroy(Conferences,NULL);
+  pNextCS = (ConfServer *)avl_t_first(&avl_trans, Conferences);
+  while ((pCS = pNextCS) != NULL) {
+    pNextCS = (ConfServer *)avl_t_next(&avl_trans);
+    DeleteConf(pCS);
+  }
+  avl_destroy(Conferences, NULL);
 
 #if 0 // !!! find out why this blows chow someday
    if(CmdClient != NULL) {
@@ -8252,100 +7832,96 @@ void ConferenceCleanup()
 #endif
 }
 
-void SendChatEvent(char *Type,char *Buf)
-{
-   char *Text = &Buf[sizeof(NDATA)];
-   char *cp;
+void SendChatEvent(char *Type, char *Buf) {
+  char *Text = &Buf[sizeof(NDATA)];
+  char *cp;
 
-// Remove carrage return from text
-   if((cp = strchr(Text,'\r')) != NULL) {
-      *cp = 0;
-   }
+  // Remove carrage return from text
+  if ((cp = strchr(Text, '\r')) != NULL) {
+    *cp = 0;
+  }
 
-   if(strlen(Text) > 0) {
-      EventHook("%s %s",Type,Text);
-   }
+  if (strlen(Text) > 0) {
+    EventHook("%s %s", Type, Text);
+  }
 
-   if(cp != NULL) {
-      *cp = '\r';
-   }
+  if (cp != NULL) {
+    *cp = '\r';
+  }
 }
 
-int GetCmdOptions(char **args,const char *opts)
-{
-   int Ret = -1;
-   char *cp = *args;
-   char *cp1;
-   int bQuoted = FALSE;
+int GetCmdOptions(char **args, const char *opts) {
+  int Ret = -1;
+  char *cp = *args;
+  char *cp1;
+  int bQuoted = FALSE;
 
-   CmdArg = NULL;
-   do {
-      while(isspace(*cp)) {
-         cp++;
-      }
-      if(*cp != '-') {
-      // not a switch we're done
-         break;
-      }
+  CmdArg = NULL;
+  do {
+    while (isspace(*cp)) {
       cp++;
-      if((cp1 = strchr(opts,*cp)) == NULL) {
+    }
+    if (*cp != '-') {
+      // not a switch we're done
+      break;
+    }
+    cp++;
+    if ((cp1 = strchr(opts, *cp)) == NULL) {
       // undefined option
-         Ret = '?';
-         break;
+      Ret = '?';
+      break;
+    }
+
+    Ret = *cp++; // Valid option found
+
+    if (cp1[1] == ':') {
+      // option has an argument
+      while (isspace(*cp)) {
+        cp++;
+      }
+      if (!isprint(*cp) || *cp == '-') {
+        // invalid or no argument specified
+        break;
       }
 
-      Ret = *cp++;   // Valid option found
-
-      if(cp1[1] == ':') {
-      // option has an argument
-         while(isspace(*cp)) {
-            cp++;
-         }
-         if(!isprint(*cp) || *cp == '-') {
-         // invalid or no argument specified
-            break;
-         }
-
-         if(*cp == '"') {
-            cp++;
-            bQuoted = TRUE;
-         }
+      if (*cp == '"') {
+        cp++;
+        bQuoted = TRUE;
+      }
       // Save pointer to argument
-         CmdArg = cp;
+      CmdArg = cp;
       // Skip to the end of argument
 
-         if(bQuoted) {
-            while(isprint(*cp) && *cp != '"') {
-               cp++;
-            }
-            if(*cp != '"') {
-            // improper termination of quoted argument
-               CmdArg = NULL;
-            }
-         }
-         else {
-            while(!isspace(*cp) && isprint(*cp) && *cp != '-') {
-               cp++;
-            }
-         }
-         *cp++ = 0;  // terminate it
+      if (bQuoted) {
+        while (isprint(*cp) && *cp != '"') {
+          cp++;
+        }
+        if (*cp != '"') {
+          // improper termination of quoted argument
+          CmdArg = NULL;
+        }
+      } else {
+        while (!isspace(*cp) && isprint(*cp) && *cp != '-') {
+          cp++;
+        }
       }
-   } while(FALSE);
+      *cp++ = 0; // terminate it
+    }
+  } while (FALSE);
 
-   *args = cp;
-   return Ret;
+  *args = cp;
+  return Ret;
 }
 
-char *CallLog(ConfClient *pCC)
-{
-   static char IPAddress[1024];
-   char *Ret = pCC->Callsign;
+char *CallLog(ConfClient *pCC) {
+  static char IPAddress[1024];
+  char *Ret = pCC->Callsign;
 
-   if(LogIPAddresses) {
-      snprintf(IPAddress,sizeof(IPAddress),"%s (%s)",pCC->Callsign,
-               inet_ntoa(pCC->HisAdr.i.sin_addr));
-      Ret = IPAddress;
-   }
+  if (LogIPAddresses) {
+    snprintf(IPAddress, sizeof(IPAddress), "%s (%s)", pCC->Callsign,
+             inet_ntoa(pCC->HisAdr.i.sin_addr));
+    Ret = IPAddress;
+  }
 
-   return Ret;
+  return Ret;
 }


### PR DESCRIPTION
This fixes a reproducible buffer overflow in GenBye() when building RTCP BYE packets.

When an EchoLink client is rejected due to a directory IP mismatch, GenBye() copies the reason string into the RTCP buffer using strcpy() with no bounds checking. On systems with glibc fortify or ASAN enabled, this reliably triggers a *** buffer overflow detected *** abort.

The fix replaces the unsafe copy with bounded handling of the reason string, preventing memory corruption while keeping the existing packet format and behaviour intact.

I reproduced the crash locally with ASAN and gdb; the backtrace consistently shows __strcpy_chk → GenBye().
